### PR TITLE
entc/gen: suspended goimports after files were written

### DIFF
--- a/dialect/dialect.go
+++ b/dialect/dialect.go
@@ -15,9 +15,10 @@ import (
 
 // Dialect names for external usage.
 const (
-	MySQL   = "mysql"
-	SQLite  = "sqlite3"
-	Gremlin = "gremlin"
+	MySQL    = "mysql"
+	SQLite   = "sqlite3"
+	Postgres = "postgres"
+	Gremlin  = "gremlin"
 )
 
 // ExecQuerier wraps the 2 database operations.

--- a/dialect/sql/builder_test.go
+++ b/dialect/sql/builder_test.go
@@ -8,6 +8,8 @@ import (
 	"strconv"
 	"testing"
 
+	"github.com/facebookincubator/ent/dialect"
+
 	"github.com/stretchr/testify/require"
 )
 
@@ -29,6 +31,14 @@ func TestBuilder(t *testing.T) {
 				).
 				PrimaryKey("id"),
 			wantQuery: "CREATE TABLE `users`(`id` int auto_increment, `name` varchar(255), PRIMARY KEY(`id`))",
+		},
+		{
+			input: Dialect(dialect.Postgres).CreateTable("users").
+				Columns(
+					Column("id").Type("serial").Attr("PRIMARY KEY"),
+					Column("name").Type("varchar"),
+				),
+			wantQuery: `CREATE TABLE "users"("id" serial PRIMARY KEY, "name" varchar)`,
 		},
 		{
 			input: CreateTable("users").
@@ -73,6 +83,18 @@ func TestBuilder(t *testing.T) {
 			wantQuery: "CREATE TABLE IF NOT EXISTS `users`(`id` int auto_increment, `card_id` int, PRIMARY KEY(`id`, `name`), FOREIGN KEY(`card_id`) REFERENCES `cards`(`id`) ON DELETE SET NULL)",
 		},
 		{
+			input: Dialect(dialect.Postgres).CreateTable("users").
+				IfNotExists().
+				Columns(
+					Column("id").Type("serial"),
+					Column("card_id").Type("int"),
+				).
+				PrimaryKey("id", "name").
+				ForeignKeys(ForeignKey().Columns("card_id").
+					Reference(Reference().Table("cards").Columns("id")).OnDelete("SET NULL")),
+			wantQuery: `CREATE TABLE IF NOT EXISTS "users"("id" serial, "card_id" int, PRIMARY KEY("id", "name"), FOREIGN KEY("card_id") REFERENCES "cards"("id") ON DELETE SET NULL)`,
+		},
+		{
 			input: AlterTable("users").
 				AddColumn(Column("group_id").Type("int").Attr("UNIQUE")).
 				AddForeignKey(ForeignKey().Columns("group_id").
@@ -80,6 +102,15 @@ func TestBuilder(t *testing.T) {
 					OnDelete("CASCADE"),
 				),
 			wantQuery: "ALTER TABLE `users` ADD COLUMN `group_id` int UNIQUE, ADD CONSTRAINT FOREIGN KEY(`group_id`) REFERENCES `groups`(`id`) ON DELETE CASCADE",
+		},
+		{
+			input: Dialect(dialect.Postgres).AlterTable("users").
+				AddColumn(Column("group_id").Type("int").Attr("UNIQUE")).
+				AddForeignKey(ForeignKey("constraint").Columns("group_id").
+					Reference(Reference().Table("groups").Columns("id")).
+					OnDelete("CASCADE"),
+				),
+			wantQuery: `ALTER TABLE "users" ADD COLUMN "group_id" int UNIQUE, ADD CONSTRAINT "constraint" FOREIGN KEY("group_id") REFERENCES "groups"("id") ON DELETE CASCADE`,
 		},
 		{
 			input: AlterTable("users").
@@ -90,10 +121,24 @@ func TestBuilder(t *testing.T) {
 			wantQuery: "ALTER TABLE `users` ADD COLUMN `group_id` int UNIQUE, ADD CONSTRAINT FOREIGN KEY(`group_id`) REFERENCES `groups`(`id`)",
 		},
 		{
+			input: Dialect(dialect.Postgres).AlterTable("users").
+				AddColumn(Column("group_id").Type("int").Attr("UNIQUE")).
+				AddForeignKey(ForeignKey().Columns("group_id").
+					Reference(Reference().Table("groups").Columns("id")),
+				),
+			wantQuery: `ALTER TABLE "users" ADD COLUMN "group_id" int UNIQUE, ADD CONSTRAINT FOREIGN KEY("group_id") REFERENCES "groups"("id")`,
+		},
+		{
 			input: AlterTable("users").
 				AddColumn(Column("age").Type("int")).
 				AddColumn(Column("name").Type("varchar(255)")),
 			wantQuery: "ALTER TABLE `users` ADD COLUMN `age` int, ADD COLUMN `name` varchar(255)",
+		},
+		{
+			input: Dialect(dialect.Postgres).AlterTable("users").
+				AddColumn(Column("age").Type("int")).
+				AddColumn(Column("name").Type("varchar(255)")),
+			wantQuery: `ALTER TABLE "users" ADD COLUMN "age" int, ADD COLUMN "name" varchar(255)`,
 		},
 		{
 			input: AlterTable("users").
@@ -111,14 +156,37 @@ func TestBuilder(t *testing.T) {
 			wantQuery: "ALTER TABLE `users` MODIFY COLUMN `age` int",
 		},
 		{
+			input: Dialect(dialect.Postgres).AlterTable("users").
+				ModifyColumn(Column("age").Type("int")),
+			wantQuery: `ALTER TABLE "users" ALTER COLUMN "age" TYPE int`,
+		},
+		{
 			input: AlterTable("users").
 				ModifyColumn(Column("age").Type("int")).
 				DropColumn(Column("name")),
 			wantQuery: "ALTER TABLE `users` MODIFY COLUMN `age` int, DROP COLUMN `name`",
 		},
 		{
+			input: Dialect(dialect.Postgres).AlterTable("users").
+				ModifyColumn(Column("age").Type("int")).
+				DropColumn(Column("name")),
+			wantQuery: `ALTER TABLE "users" ALTER COLUMN "age" TYPE int, DROP COLUMN "name"`,
+		},
+		{
+			input: Dialect(dialect.Postgres).AlterTable("users").
+				AddColumn(Column("boring").Type("varchar")).
+				ModifyColumn(Column("age").Type("int")).
+				DropColumn(Column("name")),
+			wantQuery: `ALTER TABLE "users" ADD COLUMN "boring" varchar, ALTER COLUMN "age" TYPE int, DROP COLUMN "name"`,
+		},
+		{
 			input:     Insert("users").Columns("age").Values(1),
 			wantQuery: "INSERT INTO `users` (`age`) VALUES (?)",
+			wantArgs:  []interface{}{1},
+		},
+		{
+			input:     Dialect(dialect.Postgres).Insert("users").Columns("age").Values(1),
+			wantQuery: `INSERT INTO "users" ("age") VALUES ($1)`,
 			wantArgs:  []interface{}{1},
 		},
 		{
@@ -127,13 +195,37 @@ func TestBuilder(t *testing.T) {
 			wantArgs:  []interface{}{"a8m", 10},
 		},
 		{
+			input:     Dialect(dialect.Postgres).Insert("users").Columns("name", "age").Values("a8m", 10),
+			wantQuery: `INSERT INTO "users" ("name", "age") VALUES ($1, $2)`,
+			wantArgs:  []interface{}{"a8m", 10},
+		},
+		{
 			input:     Insert("users").Columns("name", "age").Values("a8m", 10).Values("foo", 20),
 			wantQuery: "INSERT INTO `users` (`name`, `age`) VALUES (?, ?), (?, ?)",
 			wantArgs:  []interface{}{"a8m", 10, "foo", 20},
 		},
 		{
+			input:     Dialect(dialect.Postgres).Insert("users").Columns("name", "age").Values("a8m", 10).Values("foo", 20),
+			wantQuery: `INSERT INTO "users" ("name", "age") VALUES ($1, $2), ($3, $4)`,
+			wantArgs:  []interface{}{"a8m", 10, "foo", 20},
+		},
+		{
+			input: Dialect(dialect.Postgres).Insert("users").
+				Columns("name", "age").
+				Values("a8m", 10).
+				Values("foo", 20).
+				Values("bar", 30),
+			wantQuery: `INSERT INTO "users" ("name", "age") VALUES ($1, $2), ($3, $4), ($5, $6)`,
+			wantArgs:  []interface{}{"a8m", 10, "foo", 20, "bar", 30},
+		},
+		{
 			input:     Update("users").Set("name", "foo"),
 			wantQuery: "UPDATE `users` SET `name` = ?",
+			wantArgs:  []interface{}{"foo"},
+		},
+		{
+			input:     Dialect(dialect.Postgres).Update("users").Set("name", "foo"),
+			wantQuery: `UPDATE "users" SET "name" = $1`,
 			wantArgs:  []interface{}{"foo"},
 		},
 		{
@@ -142,8 +234,18 @@ func TestBuilder(t *testing.T) {
 			wantArgs:  []interface{}{"foo", 10},
 		},
 		{
+			input:     Dialect(dialect.Postgres).Update("users").Set("name", "foo").Set("age", 10),
+			wantQuery: `UPDATE "users" SET "name" = $1, "age" = $2`,
+			wantArgs:  []interface{}{"foo", 10},
+		},
+		{
 			input:     Update("users").Set("name", "foo").Where(EQ("name", "bar")),
 			wantQuery: "UPDATE `users` SET `name` = ? WHERE `name` = ?",
+			wantArgs:  []interface{}{"foo", "bar"},
+		},
+		{
+			input:     Dialect(dialect.Postgres).Update("users").Set("name", "foo").Where(EQ("name", "bar")),
+			wantQuery: `UPDATE "users" SET "name" = $1 WHERE "name" = $2`,
 			wantArgs:  []interface{}{"foo", "bar"},
 		},
 		{
@@ -152,10 +254,24 @@ func TestBuilder(t *testing.T) {
 			wantArgs:  []interface{}{"foo"},
 		},
 		{
+			input:     Dialect(dialect.Postgres).Update("users").Set("name", "foo").SetNull("spouse_id"),
+			wantQuery: `UPDATE "users" SET "spouse_id" = NULL, "name" = $1`,
+			wantArgs:  []interface{}{"foo"},
+		},
+		{
 			input: Update("users").Set("name", "foo").
 				Where(EQ("name", "bar")).
 				Where(EQ("age", 20)),
 			wantQuery: "UPDATE `users` SET `name` = ? WHERE `name` = ? AND `age` = ?",
+			wantArgs:  []interface{}{"foo", "bar", 20},
+		},
+		{
+			input: Dialect(dialect.Postgres).
+				Update("users").
+				Set("name", "foo").
+				Where(EQ("name", "bar")).
+				Where(EQ("age", 20)),
+			wantQuery: `UPDATE "users" SET "name" = $1 WHERE "name" = $2 AND "age" = $3`,
 			wantArgs:  []interface{}{"foo", "bar", 20},
 		},
 		{
@@ -167,11 +283,29 @@ func TestBuilder(t *testing.T) {
 			wantArgs:  []interface{}{"foo", 10, "bar", "baz"},
 		},
 		{
+			input: Dialect(dialect.Postgres).
+				Update("users").
+				Set("name", "foo").
+				Set("age", 10).
+				Where(EQ("name", "bar").Or().EQ("name", "baz")),
+			wantQuery: `UPDATE "users" SET "name" = $1, "age" = $2 WHERE "name" = $3 OR "name" = $4`,
+			wantArgs:  []interface{}{"foo", 10, "bar", "baz"},
+		},
+		{
 			input: Update("users").
 				Set("name", "foo").
 				Set("age", 10).
 				Where(P().EQ("name", "foo")),
 			wantQuery: "UPDATE `users` SET `name` = ?, `age` = ? WHERE `name` = ?",
+			wantArgs:  []interface{}{"foo", 10, "foo"},
+		},
+		{
+			input: Dialect(dialect.Postgres).
+				Update("users").
+				Set("name", "foo").
+				Set("age", 10).
+				Where(P().EQ("name", "foo")),
+			wantQuery: `UPDATE "users" SET "name" = $1, "age" = $2 WHERE "name" = $3`,
 			wantArgs:  []interface{}{"foo", 10, "foo"},
 		},
 		{
@@ -182,6 +316,14 @@ func TestBuilder(t *testing.T) {
 			wantArgs:  []interface{}{"foo", "bar", "baz", 1, 2},
 		},
 		{
+			input: Dialect(dialect.Postgres).
+				Update("users").
+				Set("name", "foo").
+				Where(In("name", "bar", "baz").And().NotIn("age", 1, 2)),
+			wantQuery: `UPDATE "users" SET "name" = $1 WHERE "name" IN ($2, $3) AND "age" NOT IN ($4, $5)`,
+			wantArgs:  []interface{}{"foo", "bar", "baz", 1, 2},
+		},
+		{
 			input: Update("users").
 				Set("name", "foo").
 				Where(HasPrefix("nickname", "a8m").And().Contains("lastname", "mash")),
@@ -189,10 +331,26 @@ func TestBuilder(t *testing.T) {
 			wantArgs:  []interface{}{"foo", "a8m%", "%mash%"},
 		},
 		{
+			input: Dialect(dialect.Postgres).
+				Update("users").
+				Set("name", "foo").
+				Where(HasPrefix("nickname", "a8m").And().Contains("lastname", "mash")),
+			wantQuery: `UPDATE "users" SET "name" = $1 WHERE "nickname" LIKE $2 AND "lastname" LIKE $3`,
+			wantArgs:  []interface{}{"foo", "a8m%", "%mash%"},
+		},
+		{
 			input: Update("users").
 				Add("age", 1).
 				Where(HasPrefix("nickname", "a8m")),
 			wantQuery: "UPDATE `users` SET `age` = COALESCE(`age`, ?) + ? WHERE `nickname` LIKE ?",
+			wantArgs:  []interface{}{0, 1, "a8m%"},
+		},
+		{
+			input: Dialect(dialect.Postgres).
+				Update("users").
+				Add("age", 1).
+				Where(HasPrefix("nickname", "a8m")),
+			wantQuery: `UPDATE "users" SET "age" = COALESCE("age", $1) + $2 WHERE "nickname" LIKE $3`,
 			wantArgs:  []interface{}{0, 1, "a8m%"},
 		},
 		{
@@ -205,32 +363,55 @@ func TestBuilder(t *testing.T) {
 			wantArgs:  []interface{}{0, 1, "a8m", 0, 10, "mashraki"},
 		},
 		{
-			input: Select().
-				From(Table("users")).
-				Where(EqualFold("name", "Alex")),
-			wantQuery: "SELECT * FROM `users` WHERE LOWER(`name`) = ?",
-			wantArgs:  []interface{}{"alex"},
+			input: Dialect(dialect.Postgres).
+				Update("users").
+				Add("age", 1).
+				Set("nickname", "a8m").
+				Add("version", 10).
+				Set("name", "mashraki"),
+			wantQuery: `UPDATE "users" SET "age" = COALESCE("age", $1) + $2, "nickname" = $3, "version" = COALESCE("version", $4) + $5, "name" = $6`,
+			wantArgs:  []interface{}{0, 1, "a8m", 0, 10, "mashraki"},
+		},
+		{
+			input: Dialect(dialect.Postgres).
+				Update("users").
+				Add("age", 1).
+				Set("nickname", "a8m").
+				Add("version", 10).
+				Set("name", "mashraki").
+				Set("first", "ariel").
+				Add("score", 1e5).
+				Where(EQ("age", 1).Or().EQ("age", 2)),
+			wantQuery: `UPDATE "users" SET "age" = COALESCE("age", $1) + $2, "nickname" = $3, "version" = COALESCE("version", $4) + $5, "name" = $6, "first" = $7, "score" = COALESCE("score", $8) + $9 WHERE "age" = $10 OR "age" = $11`,
+			wantArgs:  []interface{}{0, 1, "a8m", 0, 10, "mashraki", "ariel", 0, 1e5, 1, 2},
 		},
 		{
 			input: Select().
 				From(Table("users")).
-				Where(EqualFold("name", "BAR").Or().EqualFold("name", "BAZ")),
-			wantQuery: "SELECT * FROM `users` WHERE LOWER(`name`) = ? OR LOWER(`name`) = ?",
-			wantArgs:  []interface{}{"bar", "baz"},
+				Where(EQ("name", "Alex")),
+			wantQuery: "SELECT * FROM `users` WHERE `name` = ?",
+			wantArgs:  []interface{}{"Alex"},
+		},
+		{
+			input: Dialect(dialect.Postgres).
+				Select().
+				From(Table("users")),
+			wantQuery: `SELECT * FROM "users"`,
+		},
+		{
+			input: Dialect(dialect.Postgres).
+				Select().
+				From(Table("users")).
+				Where(EQ("name", "Ariel")),
+			wantQuery: `SELECT * FROM "users" WHERE "name" = $1`,
+			wantArgs:  []interface{}{"Ariel"},
 		},
 		{
 			input: Select().
 				From(Table("users")).
-				Where(ContainsFold("name", "Ariel")),
-			wantQuery: "SELECT * FROM `users` WHERE LOWER(`name`) LIKE ?",
-			wantArgs:  []interface{}{"%ariel%"},
-		},
-		{
-			input: Select().
-				From(Table("users")).
-				Where(ContainsFold("name", "Ariel").And().ContainsFold("nick", "Bar")),
-			wantQuery: "SELECT * FROM `users` WHERE LOWER(`name`) LIKE ? AND LOWER(`nick`) LIKE ?",
-			wantArgs:  []interface{}{"%ariel%", "%bar%"},
+				Where(EQ("name", "BAR").Or().EQ("name", "BAZ")),
+			wantQuery: "SELECT * FROM `users` WHERE `name` = ? OR `name` = ?",
+			wantArgs:  []interface{}{"BAR", "BAZ"},
 		},
 		{
 			input: Update("users").
@@ -246,9 +427,10 @@ func TestBuilder(t *testing.T) {
 			wantQuery: "DELETE FROM `users` WHERE `parent_id` IS NOT NULL",
 		},
 		{
-			input: Delete("users").
+			input: Dialect(dialect.Postgres).
+				Delete("users").
 				Where(IsNull("parent_id")),
-			wantQuery: "DELETE FROM `users` WHERE `parent_id` IS NULL",
+			wantQuery: `DELETE FROM "users" WHERE "parent_id" IS NULL`,
 		},
 		{
 			input: Delete("users").
@@ -257,14 +439,34 @@ func TestBuilder(t *testing.T) {
 			wantArgs:  []interface{}{"foo", "bar"},
 		},
 		{
+			input: Dialect(dialect.Postgres).
+				Delete("users").
+				Where(IsNull("parent_id").And().NotIn("name", "foo", "bar")),
+			wantQuery: `DELETE FROM "users" WHERE "parent_id" IS NULL AND "name" NOT IN ($1, $2)`,
+			wantArgs:  []interface{}{"foo", "bar"},
+		},
+		{
 			input: Delete("users").
 				Where(False().And().False()),
 			wantQuery: "DELETE FROM `users` WHERE FALSE AND FALSE",
 		},
 		{
+			input: Dialect(dialect.Postgres).
+				Delete("users").
+				Where(False().And().False()),
+			wantQuery: `DELETE FROM "users" WHERE FALSE AND FALSE`,
+		},
+		{
 			input: Delete("users").
 				Where(NotNull("parent_id").Or().EQ("parent_id", 10)),
 			wantQuery: "DELETE FROM `users` WHERE `parent_id` IS NOT NULL OR `parent_id` = ?",
+			wantArgs:  []interface{}{10},
+		},
+		{
+			input: Dialect(dialect.Postgres).
+				Delete("users").
+				Where(NotNull("parent_id").Or().EQ("parent_id", 10)),
+			wantQuery: `DELETE FROM "users" WHERE "parent_id" IS NOT NULL OR "parent_id" = $1`,
 			wantArgs:  []interface{}{10},
 		},
 		{
@@ -283,40 +485,44 @@ func TestBuilder(t *testing.T) {
 			wantArgs:  []interface{}{"foo", 10, "bar", 20, "qux", 1, 2},
 		},
 		{
-			input: Select(Lower("name")).
-				From(Table("users")),
-			wantQuery: "SELECT LOWER(`name`) FROM `users`",
-		},
-		{
-			input: Select(Lower("name")).
-				From(Table("users")).
-				Where(EQ(Lower("name"), "a8m")),
-			wantQuery: "SELECT LOWER(`name`) FROM `users` WHERE LOWER(`name`) = ?",
-			wantArgs:  []interface{}{"a8m"},
-		},
-		{
-			input: Select(Upper("name")).
-				From(Table("users")),
-			wantQuery: "SELECT UPPER(`name`) FROM `users`",
-		},
-		{
-			input: Select(Upper("name")).
-				From(Table("users")).
-				Where(EQ(Upper("name"), "a8m")),
-			wantQuery: "SELECT UPPER(`name`) FROM `users` WHERE UPPER(`name`) = ?",
-			wantArgs:  []interface{}{"a8m"},
+			input: Dialect(dialect.Postgres).
+				Delete("users").
+				Where(
+					Or(
+						EQ("name", "foo").And().EQ("age", 10),
+						EQ("name", "bar").And().EQ("age", 20),
+						And(
+							EQ("name", "qux"),
+							EQ("age", 1).Or().EQ("age", 2),
+						),
+					),
+				),
+			wantQuery: `DELETE FROM "users" WHERE ("name" = $1 AND "age" = $2) OR ("name" = $3 AND "age" = $4) OR (("name" = $5) AND ("age" = $6 OR "age" = $7))`,
+			wantArgs:  []interface{}{"foo", 10, "bar", 20, "qux", 1, 2},
 		},
 		{
 			input:     Select().From(Table("users")),
 			wantQuery: "SELECT * FROM `users`",
 		},
 		{
+			input:     Dialect(dialect.Postgres).Select().From(Table("users")),
+			wantQuery: `SELECT * FROM "users"`,
+		},
+		{
 			input:     Select().From(Table("users").Unquote()),
+			wantQuery: "SELECT * FROM users",
+		},
+		{
+			input:     Dialect(dialect.Postgres).Select().From(Table("users").Unquote()),
 			wantQuery: "SELECT * FROM users",
 		},
 		{
 			input:     Select().From(Table("users").As("u")),
 			wantQuery: "SELECT * FROM `users` AS `u`",
+		},
+		{
+			input:     Dialect(dialect.Postgres).Select().From(Table("users").As("u")),
+			wantQuery: `SELECT * FROM "users" AS "u"`,
 		},
 		{
 			input: func() Querier {
@@ -330,12 +536,32 @@ func TestBuilder(t *testing.T) {
 			input: func() Querier {
 				t1 := Table("users").As("u")
 				t2 := Table("groups").As("g")
+				return Dialect(dialect.Postgres).Select(t1.C("id"), t2.C("name")).From(t1).Join(t2)
+			}(),
+			wantQuery: `SELECT "u"."id", "g"."name" FROM "users" AS "u" JOIN "groups" AS "g"`,
+		},
+		{
+			input: func() Querier {
+				t1 := Table("users").As("u")
+				t2 := Table("groups").As("g")
 				return Select(t1.C("id"), t2.C("name")).
 					From(t1).
 					Join(t2).
 					On(t1.C("id"), t2.C("user_id"))
 			}(),
 			wantQuery: "SELECT `u`.`id`, `g`.`name` FROM `users` AS `u` JOIN `groups` AS `g` ON `u`.`id` = `g`.`user_id`",
+		},
+		{
+			input: func() Querier {
+				t1 := Table("users").As("u")
+				t2 := Table("groups").As("g")
+				return Dialect(dialect.Postgres).
+					Select(t1.C("id"), t2.C("name")).
+					From(t1).
+					Join(t2).
+					On(t1.C("id"), t2.C("user_id"))
+			}(),
+			wantQuery: `SELECT "u"."id", "g"."name" FROM "users" AS "u" JOIN "groups" AS "g" ON "u"."id" = "g"."user_id"`,
 		},
 		{
 			input: func() Querier {
@@ -353,9 +579,40 @@ func TestBuilder(t *testing.T) {
 		{
 			input: func() Querier {
 				t1 := Table("users").As("u")
+				t2 := Table("groups").As("g")
+				return Dialect(dialect.Postgres).
+					Select(t1.C("id"), t2.C("name")).
+					From(t1).
+					Join(t2).
+					On(t1.C("id"), t2.C("user_id")).
+					Where(EQ(t1.C("name"), "bar").And().NotNull(t2.C("name")))
+			}(),
+			wantQuery: `SELECT "u"."id", "g"."name" FROM "users" AS "u" JOIN "groups" AS "g" ON "u"."id" = "g"."user_id" WHERE "u"."name" = $1 AND "g"."name" IS NOT NULL`,
+			wantArgs:  []interface{}{"bar"},
+		},
+		{
+			input: func() Querier {
+				t1 := Table("users").As("u")
 				return Select(t1.Columns("name", "age")...).From(t1)
 			}(),
 			wantQuery: "SELECT `u`.`name`, `u`.`age` FROM `users` AS `u`",
+		},
+		{
+			input: func() Querier {
+				t1 := Table("users").As("u")
+				return Dialect(dialect.Postgres).
+					Select(t1.Columns("name", "age")...).From(t1)
+			}(),
+			wantQuery: `SELECT "u"."name", "u"."age" FROM "users" AS "u"`,
+		},
+		{
+			input: func() Querier {
+				t1 := Dialect(dialect.Postgres).
+					Table("users").As("u")
+				return Dialect(dialect.Postgres).
+					Select(t1.Columns("name", "age")...).From(t1)
+			}(),
+			wantQuery: `SELECT "u"."name", "u"."age" FROM "users" AS "u"`,
 		},
 		{
 			input: func() Querier {
@@ -371,10 +628,32 @@ func TestBuilder(t *testing.T) {
 		},
 		{
 			input: func() Querier {
+				d := Dialect(dialect.Postgres)
+				t1 := d.Table("users").As("u")
+				t2 := d.Select().From(Table("groups")).Where(EQ("user_id", 10)).As("g")
+				return d.Select(t1.C("id"), t2.C("name")).
+					From(t1).
+					Join(t2).
+					On(t1.C("id"), t2.C("user_id"))
+			}(),
+			wantQuery: `SELECT "u"."id", "g"."name" FROM "users" AS "u" JOIN (SELECT * FROM "groups" WHERE "user_id" = $1) AS "g" ON "u"."id" = "g"."user_id"`,
+			wantArgs:  []interface{}{10},
+		},
+		{
+			input: func() Querier {
 				selector := Select().Where(EQ("name", "foo").Or().EQ("name", "bar"))
 				return Delete("users").FromSelect(selector)
 			}(),
 			wantQuery: "DELETE FROM `users` WHERE `name` = ? OR `name` = ?",
+			wantArgs:  []interface{}{"foo", "bar"},
+		},
+		{
+			input: func() Querier {
+				d := Dialect(dialect.Postgres)
+				selector := d.Select().Where(EQ("name", "foo").Or().EQ("name", "bar"))
+				return d.Delete("users").FromSelect(selector)
+			}(),
+			wantQuery: `DELETE FROM "users" WHERE "name" = $1 OR "name" = $2`,
 			wantArgs:  []interface{}{"foo", "bar"},
 		},
 		{
@@ -386,10 +665,27 @@ func TestBuilder(t *testing.T) {
 		},
 		{
 			input: func() Querier {
+				selector := Dialect(dialect.Postgres).
+					Select().From(Table("users")).As("t")
+				return selector.Select(selector.C("name"))
+			}(),
+			wantQuery: `SELECT "t"."name" FROM "users"`,
+		},
+		{
+			input: func() Querier {
 				selector := Select().From(Table("groups")).Where(EQ("name", "foo"))
 				return Delete("users").FromSelect(selector)
 			}(),
 			wantQuery: "DELETE FROM `groups` WHERE `name` = ?",
+			wantArgs:  []interface{}{"foo"},
+		},
+		{
+			input: func() Querier {
+				d := Dialect(dialect.Postgres)
+				selector := d.Select().From(Table("groups")).Where(EQ("name", "foo"))
+				return d.Delete("users").FromSelect(selector)
+			}(),
+			wantQuery: `DELETE FROM "groups" WHERE "name" = $1`,
 			wantArgs:  []interface{}{"foo"},
 		},
 		{
@@ -400,16 +696,77 @@ func TestBuilder(t *testing.T) {
 			wantQuery: "DELETE FROM `users`",
 		},
 		{
-			input:     Select().From(Table("users")).Where(Not(EQ("name", "foo").And().EQ("age", "bar"))),
+			input: func() Querier {
+				d := Dialect(dialect.Postgres)
+				selector := d.Select()
+				return d.Delete("users").FromSelect(selector)
+			}(),
+			wantQuery: `DELETE FROM "users"`,
+		},
+		{
+			input: Select().
+				From(Table("users")).
+				Where(Not(EQ("name", "foo").And().EQ("age", "bar"))),
 			wantQuery: "SELECT * FROM `users` WHERE NOT (`name` = ? AND `age` = ?)",
 			wantArgs:  []interface{}{"foo", "bar"},
 		},
 		{
+			input: Dialect(dialect.Postgres).
+				Select().
+				From(Table("users")).
+				Where(Not(EQ("name", "foo").And().EQ("age", "bar"))),
+			wantQuery: `SELECT * FROM "users" WHERE NOT ("name" = $1 AND "age" = $2)`,
+			wantArgs:  []interface{}{"foo", "bar"},
+		},
+		{
+			input: Select().
+				From(Table("users")).
+				Where(EqualFold("name", "BAR").Or().EqualFold("name", "BAZ")),
+			wantQuery: "SELECT * FROM `users` WHERE LOWER(`name`) = ? OR LOWER(`name`) = ?",
+			wantArgs:  []interface{}{"bar", "baz"},
+		},
+		{
+			input: Dialect(dialect.Postgres).
+				Select().
+				From(Table("users")).
+				Where(EqualFold("name", "BAR").Or().EqualFold("name", "BAZ")),
+			wantQuery: `SELECT * FROM "users" WHERE LOWER("name") = $1 OR LOWER("name") = $2`,
+			wantArgs:  []interface{}{"bar", "baz"},
+		},
+		{
+			input: Select().
+				From(Table("users")).
+				Where(ContainsFold("name", "Ariel").And().ContainsFold("nick", "Bar")),
+			wantQuery: "SELECT * FROM `users` WHERE LOWER(`name`) LIKE ? AND LOWER(`nick`) LIKE ?",
+			wantArgs:  []interface{}{"%ariel%", "%bar%"},
+		},
+		{
+			input: Dialect(dialect.Postgres).
+				Select().
+				From(Table("users")).
+				Where(ContainsFold("name", "Ariel").And().ContainsFold("nick", "Bar")),
+			wantQuery: `SELECT * FROM "users" WHERE LOWER("name") LIKE $1 AND LOWER("nick") LIKE $2`,
+			wantArgs:  []interface{}{"%ariel%", "%bar%"},
+		},
+		{
 			input: func() Querier {
-				s1 := Select().From(Table("users")).Where(Not(EQ("name", "foo").And().EQ("age", "bar")))
+				s1 := Select().
+					From(Table("users")).
+					Where(Not(EQ("name", "foo").And().EQ("age", "bar")))
 				return Queries{With("users_view").As(s1), Select("name").From(Table("users_view"))}
 			}(),
 			wantQuery: "WITH users_view AS (SELECT * FROM `users` WHERE NOT (`name` = ? AND `age` = ?)) SELECT `name` FROM `users_view`",
+			wantArgs:  []interface{}{"foo", "bar"},
+		},
+		{
+			input: func() Querier {
+				d := Dialect(dialect.Postgres)
+				s1 := d.Select().
+					From(Table("users")).
+					Where(Not(EQ("name", "foo").And().EQ("age", "bar")))
+				return Queries{d.With("users_view").As(s1), d.Select("name").From(Table("users_view"))}
+			}(),
+			wantQuery: `WITH users_view AS (SELECT * FROM "users" WHERE NOT ("name" = $1 AND "age" = $2)) SELECT "name" FROM "users_view"`,
 			wantArgs:  []interface{}{"foo", "bar"},
 		},
 		{
@@ -418,6 +775,15 @@ func TestBuilder(t *testing.T) {
 				return Select("name").From(s1)
 			}(),
 			wantQuery: "SELECT `name` FROM (SELECT * FROM `users` WHERE NOT (`name` = ? AND `age` = ?)) AS `users_view`",
+			wantArgs:  []interface{}{"foo", "bar"},
+		},
+		{
+			input: func() Querier {
+				d := Dialect(dialect.Postgres)
+				s1 := d.Select().From(Table("users")).Where(Not(EQ("name", "foo").And().EQ("age", "bar"))).As("users_view")
+				return d.Select("name").From(s1)
+			}(),
+			wantQuery: `SELECT "name" FROM (SELECT * FROM "users" WHERE NOT ("name" = $1 AND "age" = $2)) AS "users_view"`,
 			wantArgs:  []interface{}{"foo", "bar"},
 		},
 		{
@@ -433,6 +799,17 @@ func TestBuilder(t *testing.T) {
 		{
 			input: func() Querier {
 				t1 := Table("users")
+				return Dialect(dialect.Postgres).
+					Select().
+					From(t1).
+					Where(In(t1.C("id"), Select("owner_id").From(Table("pets")).Where(EQ("name", "pedro"))))
+			}(),
+			wantQuery: `SELECT * FROM "users" WHERE "users"."id" IN (SELECT "owner_id" FROM "pets" WHERE "name" = $1)`,
+			wantArgs:  []interface{}{"pedro"},
+		},
+		{
+			input: func() Querier {
+				t1 := Table("users")
 				return Select().
 					From(t1).
 					Where(Not(In(t1.C("id"), Select("owner_id").From(Table("pets")).Where(EQ("name", "pedro")))))
@@ -441,12 +818,33 @@ func TestBuilder(t *testing.T) {
 			wantArgs:  []interface{}{"pedro"},
 		},
 		{
+			input: func() Querier {
+				t1 := Table("users")
+				return Dialect(dialect.Postgres).
+					Select().
+					From(t1).
+					Where(Not(In(t1.C("id"), Select("owner_id").From(Table("pets")).Where(EQ("name", "pedro")))))
+			}(),
+			wantQuery: `SELECT * FROM "users" WHERE NOT ("users"."id" IN (SELECT "owner_id" FROM "pets" WHERE "name" = $1))`,
+			wantArgs:  []interface{}{"pedro"},
+		},
+		{
 			input:     Select().Count().From(Table("users")),
 			wantQuery: "SELECT COUNT(*) FROM `users`",
 		},
 		{
+			input: Dialect(dialect.Postgres).
+				Select().Count().From(Table("users")),
+			wantQuery: `SELECT COUNT(*) FROM "users"`,
+		},
+		{
 			input:     Select().Count(Distinct("id")).From(Table("users")),
 			wantQuery: "SELECT COUNT(DISTINCT `id`) FROM `users`",
+		},
+		{
+			input: Dialect(dialect.Postgres).
+				Select().Count(Distinct("id")).From(Table("users")),
+			wantQuery: `SELECT COUNT(DISTINCT "id") FROM "users"`,
 		},
 		{
 			input: func() Querier {
@@ -458,8 +856,24 @@ func TestBuilder(t *testing.T) {
 			wantQuery: "SELECT COUNT(DISTINCT `t0`.`id`, `t0`.`name`) FROM `users` AS `t0` JOIN `users` AS `t0` ON `groups`.`id` = `t0`.`blocked_id`",
 		},
 		{
+			input: func() Querier {
+				d := Dialect(dialect.Postgres)
+				t1 := d.Table("users")
+				t2 := d.Select().From(Table("groups"))
+				t3 := d.Select().Count().From(t1).Join(t1).On(t2.C("id"), t1.C("blocked_id"))
+				return t3.Count(Distinct(t3.Columns("id", "name")...))
+			}(),
+			wantQuery: `SELECT COUNT(DISTINCT "t0"."id", "t0"."name") FROM "users" AS "t0" JOIN "users" AS "t0" ON "groups"."id" = "t0"."blocked_id"`,
+		},
+		{
 			input:     Select(Sum("age"), Min("age")).From(Table("users")),
 			wantQuery: "SELECT SUM(`age`), MIN(`age`) FROM `users`",
+		},
+		{
+			input: Dialect(dialect.Postgres).
+				Select(Sum("age"), Min("age")).
+				From(Table("users")),
+			wantQuery: `SELECT SUM("age"), MIN("age") FROM "users"`,
 		},
 		{
 			input: func() Querier {
@@ -469,10 +883,26 @@ func TestBuilder(t *testing.T) {
 			wantQuery: "SELECT MAX(`u`.`age`) AS `max_age` FROM `users` AS `u`",
 		},
 		{
+			input: func() Querier {
+				t1 := Table("users").As("u")
+				return Dialect(dialect.Postgres).
+					Select(As(Max(t1.C("age")), "max_age")).
+					From(t1)
+			}(),
+			wantQuery: `SELECT MAX("u"."age") AS "max_age" FROM "users" AS "u"`,
+		},
+		{
 			input: Select("name", Count("*")).
 				From(Table("users")).
 				GroupBy("name"),
 			wantQuery: "SELECT `name`, COUNT(*) FROM `users` GROUP BY `name`",
+		},
+		{
+			input: Dialect(dialect.Postgres).
+				Select("name", Count("*")).
+				From(Table("users")).
+				GroupBy("name"),
+			wantQuery: `SELECT "name", COUNT(*) FROM "users" GROUP BY "name"`,
 		},
 		{
 			input: Select("name", Count("*")).
@@ -482,6 +912,14 @@ func TestBuilder(t *testing.T) {
 			wantQuery: "SELECT `name`, COUNT(*) FROM `users` GROUP BY `name` ORDER BY `name`",
 		},
 		{
+			input: Dialect(dialect.Postgres).
+				Select("name", Count("*")).
+				From(Table("users")).
+				GroupBy("name").
+				OrderBy("name"),
+			wantQuery: `SELECT "name", COUNT(*) FROM "users" GROUP BY "name" ORDER BY "name"`,
+		},
+		{
 			input: Select("name", "age", Count("*")).
 				From(Table("users")).
 				GroupBy("name", "age").
@@ -489,8 +927,26 @@ func TestBuilder(t *testing.T) {
 			wantQuery: "SELECT `name`, `age`, COUNT(*) FROM `users` GROUP BY `name`, `age` ORDER BY `name` DESC, `age`",
 		},
 		{
-			input:     Select("*").From(Table("users")).Limit(1),
+			input: Dialect(dialect.Postgres).
+				Select("name", "age", Count("*")).
+				From(Table("users")).
+				GroupBy("name", "age").
+				OrderBy(Desc("name"), "age"),
+			wantQuery: `SELECT "name", "age", COUNT(*) FROM "users" GROUP BY "name", "age" ORDER BY "name" DESC, "age"`,
+		},
+		{
+			input: Select("*").
+				From(Table("users")).
+				Limit(1),
 			wantQuery: "SELECT * FROM `users` LIMIT ?",
+			wantArgs:  []interface{}{1},
+		},
+		{
+			input: Dialect(dialect.Postgres).
+				Select("*").
+				From(Table("users")).
+				Limit(1),
+			wantQuery: `SELECT * FROM "users" LIMIT $1`,
 			wantArgs:  []interface{}{1},
 		},
 		{
@@ -498,12 +954,35 @@ func TestBuilder(t *testing.T) {
 			wantQuery: "SELECT DISTINCT `age` FROM `users`",
 		},
 		{
+			input: Dialect(dialect.Postgres).
+				Select("age").
+				Distinct().
+				From(Table("users")),
+			wantQuery: `SELECT DISTINCT "age" FROM "users"`,
+		},
+		{
 			input:     Select("age", "name").From(Table("users")).Distinct().OrderBy("name"),
 			wantQuery: "SELECT DISTINCT `age`, `name` FROM `users` ORDER BY `name`",
 		},
 		{
+			input: Dialect(dialect.Postgres).
+				Select("age", "name").
+				From(Table("users")).
+				Distinct().
+				OrderBy("name"),
+			wantQuery: `SELECT DISTINCT "age", "name" FROM "users" ORDER BY "name"`,
+		},
+		{
 			input:     Select("age").From(Table("users")).Where(EQ("name", "foo")).Or().Where(EQ("name", "bar")),
 			wantQuery: "SELECT `age` FROM `users` WHERE (`name` = ?) OR (`name` = ?)",
+			wantArgs:  []interface{}{"foo", "bar"},
+		},
+		{
+			input: Dialect(dialect.Postgres).
+				Select("age").
+				From(Table("users")).
+				Where(EQ("name", "foo")).Or().Where(EQ("name", "bar")),
+			wantQuery: `SELECT "age" FROM "users" WHERE ("name" = $1) OR ("name" = $2)`,
 			wantArgs:  []interface{}{"foo", "bar"},
 		},
 		{
@@ -523,12 +1002,32 @@ func TestBuilder(t *testing.T) {
 			wantQuery: "CREATE INDEX `name_index` ON `users`(`name`)",
 		},
 		{
+			input: Dialect(dialect.Postgres).
+				CreateIndex("name_index").
+				Table("users").
+				Column("name"),
+			wantQuery: `CREATE INDEX "name_index" ON "users"("name")`,
+		},
+		{
 			input:     CreateIndex("unique_name").Unique().Table("users").Columns("first", "last"),
 			wantQuery: "CREATE UNIQUE INDEX `unique_name` ON `users`(`first`, `last`)",
 		},
 		{
+			input: Dialect(dialect.Postgres).
+				CreateIndex("unique_name").
+				Unique().
+				Table("users").
+				Columns("first", "last"),
+			wantQuery: `CREATE UNIQUE INDEX "unique_name" ON "users"("first", "last")`,
+		},
+		{
 			input:     DropIndex("name_index"),
 			wantQuery: "DROP INDEX `name_index`",
+		},
+		{
+			input: Dialect(dialect.Postgres).
+				DropIndex("name_index"),
+			wantQuery: `DROP INDEX "name_index"`,
 		},
 		{
 			input:     DropIndex("name_index").Table("users"),

--- a/dialect/sql/schema/migrate.go
+++ b/dialect/sql/schema/migrate.go
@@ -202,7 +202,7 @@ func (m *Migrate) apply(ctx context.Context, tx dialect.Tx, table string, change
 		}
 	}
 	// if there's actual action to execute on ALTER TABLE.
-	if len(b.Queriers) != 0 {
+	if len(b.Queries) != 0 {
 		query, args := b.Query()
 		if err := tx.Exec(ctx, query, args, new(sql.Result)); err != nil {
 			return fmt.Errorf("alter table %q: %v", table, err)

--- a/entc/gen/internal/bindata.go
+++ b/entc/gen/internal/bindata.go
@@ -134,7 +134,7 @@ func templateBaseTmpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "template/base.tmpl", size: 5214, mode: os.FileMode(420), modTime: time.Unix(1570440164, 0)}
+	info := bindataFileInfo{name: "template/base.tmpl", size: 5214, mode: os.FileMode(420), modTime: time.Unix(1570451137, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -154,7 +154,7 @@ func templateBuilderCreateTmpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "template/builder/create.tmpl", size: 3054, mode: os.FileMode(420), modTime: time.Unix(1570346843, 0)}
+	info := bindataFileInfo{name: "template/builder/create.tmpl", size: 3054, mode: os.FileMode(420), modTime: time.Unix(1570030748, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -174,7 +174,7 @@ func templateBuilderDeleteTmpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "template/builder/delete.tmpl", size: 2446, mode: os.FileMode(420), modTime: time.Unix(1568794256, 0)}
+	info := bindataFileInfo{name: "template/builder/delete.tmpl", size: 2446, mode: os.FileMode(420), modTime: time.Unix(1568645716, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -194,7 +194,7 @@ func templateBuilderQueryTmpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "template/builder/query.tmpl", size: 16113, mode: os.FileMode(420), modTime: time.Unix(1568794256, 0)}
+	info := bindataFileInfo{name: "template/builder/query.tmpl", size: 16113, mode: os.FileMode(420), modTime: time.Unix(1568645715, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -214,7 +214,7 @@ func templateBuilderSetterTmpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "template/builder/setter.tmpl", size: 4397, mode: os.FileMode(420), modTime: time.Unix(1568897494, 0)}
+	info := bindataFileInfo{name: "template/builder/setter.tmpl", size: 4397, mode: os.FileMode(420), modTime: time.Unix(1568906061, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -234,7 +234,7 @@ func templateBuilderUpdateTmpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "template/builder/update.tmpl", size: 8088, mode: os.FileMode(420), modTime: time.Unix(1570346843, 0)}
+	info := bindataFileInfo{name: "template/builder/update.tmpl", size: 8088, mode: os.FileMode(420), modTime: time.Unix(1570030781, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -254,7 +254,7 @@ func templateClientTmpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "template/client.tmpl", size: 6205, mode: os.FileMode(420), modTime: time.Unix(1570020385, 0)}
+	info := bindataFileInfo{name: "template/client.tmpl", size: 6205, mode: os.FileMode(420), modTime: time.Unix(1570008718, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -274,7 +274,7 @@ func templateConfigTmpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "template/config.tmpl", size: 1254, mode: os.FileMode(420), modTime: time.Unix(1567406598, 0)}
+	info := bindataFileInfo{name: "template/config.tmpl", size: 1254, mode: os.FileMode(420), modTime: time.Unix(1567330565, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -294,7 +294,7 @@ func templateContextTmpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "template/context.tmpl", size: 719, mode: os.FileMode(420), modTime: time.Unix(1567406598, 0)}
+	info := bindataFileInfo{name: "template/context.tmpl", size: 719, mode: os.FileMode(420), modTime: time.Unix(1567330561, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -314,7 +314,7 @@ func templateDialectGremlinByTmpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "template/dialect/gremlin/by.tmpl", size: 1875, mode: os.FileMode(420), modTime: time.Unix(1567406598, 0)}
+	info := bindataFileInfo{name: "template/dialect/gremlin/by.tmpl", size: 1875, mode: os.FileMode(420), modTime: time.Unix(1567330626, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -334,7 +334,7 @@ func templateDialectGremlinCreateTmpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "template/dialect/gremlin/create.tmpl", size: 2763, mode: os.FileMode(420), modTime: time.Unix(1567406598, 0)}
+	info := bindataFileInfo{name: "template/dialect/gremlin/create.tmpl", size: 2763, mode: os.FileMode(420), modTime: time.Unix(1567330629, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -354,7 +354,7 @@ func templateDialectGremlinDecodeTmpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "template/dialect/gremlin/decode.tmpl", size: 2132, mode: os.FileMode(420), modTime: time.Unix(1570346843, 0)}
+	info := bindataFileInfo{name: "template/dialect/gremlin/decode.tmpl", size: 2132, mode: os.FileMode(420), modTime: time.Unix(1570281258, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -374,7 +374,7 @@ func templateDialectGremlinDeleteTmpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "template/dialect/gremlin/delete.tmpl", size: 825, mode: os.FileMode(420), modTime: time.Unix(1568794256, 0)}
+	info := bindataFileInfo{name: "template/dialect/gremlin/delete.tmpl", size: 825, mode: os.FileMode(420), modTime: time.Unix(1568645716, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -394,7 +394,7 @@ func templateDialectGremlinErrorsTmpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "template/dialect/gremlin/errors.tmpl", size: 1804, mode: os.FileMode(420), modTime: time.Unix(1567406598, 0)}
+	info := bindataFileInfo{name: "template/dialect/gremlin/errors.tmpl", size: 1804, mode: os.FileMode(420), modTime: time.Unix(1567330638, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -414,7 +414,7 @@ func templateDialectGremlinGroupTmpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "template/dialect/gremlin/group.tmpl", size: 1347, mode: os.FileMode(420), modTime: time.Unix(1567406598, 0)}
+	info := bindataFileInfo{name: "template/dialect/gremlin/group.tmpl", size: 1347, mode: os.FileMode(420), modTime: time.Unix(1567526275, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -434,7 +434,7 @@ func templateDialectGremlinMetaTmpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "template/dialect/gremlin/meta.tmpl", size: 704, mode: os.FileMode(420), modTime: time.Unix(1567406598, 0)}
+	info := bindataFileInfo{name: "template/dialect/gremlin/meta.tmpl", size: 704, mode: os.FileMode(420), modTime: time.Unix(1567330643, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -454,7 +454,7 @@ func templateDialectGremlinOpenTmpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "template/dialect/gremlin/open.tmpl", size: 542, mode: os.FileMode(420), modTime: time.Unix(1570440164, 0)}
+	info := bindataFileInfo{name: "template/dialect/gremlin/open.tmpl", size: 542, mode: os.FileMode(420), modTime: time.Unix(1570451137, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -474,7 +474,7 @@ func templateDialectGremlinPredicateTmpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "template/dialect/gremlin/predicate.tmpl", size: 3313, mode: os.FileMode(420), modTime: time.Unix(1567406598, 0)}
+	info := bindataFileInfo{name: "template/dialect/gremlin/predicate.tmpl", size: 3313, mode: os.FileMode(420), modTime: time.Unix(1567330647, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -494,7 +494,7 @@ func templateDialectGremlinQueryTmpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "template/dialect/gremlin/query.tmpl", size: 3929, mode: os.FileMode(420), modTime: time.Unix(1570346843, 0)}
+	info := bindataFileInfo{name: "template/dialect/gremlin/query.tmpl", size: 3929, mode: os.FileMode(420), modTime: time.Unix(1570094435, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -514,7 +514,7 @@ func templateDialectGremlinSelectTmpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "template/dialect/gremlin/select.tmpl", size: 1078, mode: os.FileMode(420), modTime: time.Unix(1568019515, 0)}
+	info := bindataFileInfo{name: "template/dialect/gremlin/select.tmpl", size: 1078, mode: os.FileMode(420), modTime: time.Unix(1567600027, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -534,7 +534,7 @@ func templateDialectGremlinUpdateTmpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "template/dialect/gremlin/update.tmpl", size: 6095, mode: os.FileMode(420), modTime: time.Unix(1568624278, 0)}
+	info := bindataFileInfo{name: "template/dialect/gremlin/update.tmpl", size: 6095, mode: os.FileMode(420), modTime: time.Unix(1568542264, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -554,12 +554,12 @@ func templateDialectSqlByTmpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "template/dialect/sql/by.tmpl", size: 949, mode: os.FileMode(420), modTime: time.Unix(1567406598, 0)}
+	info := bindataFileInfo{name: "template/dialect/sql/by.tmpl", size: 949, mode: os.FileMode(420), modTime: time.Unix(1567330589, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
 
-var _templateDialectSqlCreateTmpl = []byte("\x1f\x8b\x08\x00\x00\x00\x00\x00\x00\xff\xec\x58\xdf\x53\xdb\xb8\x16\x7e\xb6\xff\x8a\x73\x19\xda\xb1\x99\x20\x28\x6f\x97\x5e\xee\x0c\xcb\x8f\x99\xec\x16\x68\x09\xdd\x7d\x68\x3b\x3b\x8a\x7d\x94\x68\x51\xa4\x20\xc9\x29\x4c\xc6\xff\xfb\x8e\x64\x3b\x76\x8c\x81\x90\x76\xca\xee\xce\x3e\x25\xb6\xcf\x2f\x7d\xfa\x74\x3e\x49\xf3\xf9\xce\x56\x78\xa4\xa6\x77\x9a\x8f\xc6\x16\xf6\x76\xdf\xfc\x77\x7b\xaa\xd1\xa0\xb4\x70\x4a\x13\x1c\x2a\x75\x0d\x7d\x99\x10\x38\x14\x02\xbc\x91\x01\xf7\x5d\xcf\x30\x25\xe1\xd5\x98\x1b\x30\x2a\xd3\x09\x42\xa2\x52\x04\x6e\x40\xf0\x04\xa5\xc1\x14\x32\x99\xa2\x06\x3b\x46\x38\x9c\xd2\x64\x8c\xb0\x47\x76\xab\xaf\xc0\x54\x26\xd3\x90\x4b\xff\xfd\x5d\xff\xe8\xe4\x7c\x70\x02\x8c\x0b\x84\xf2\x9d\x56\xca\x42\xca\x35\x26\x56\xe9\x3b\x50\x0c\x6c\x23\x99\xd5\x88\x24\xdc\xda\xc9\xf3\x30\x9c\xcf\x21\x45\xc6\x25\xc2\x46\xca\xa9\xc0\xc4\xee\x98\x1b\xb1\x93\x68\xa4\x16\x37\x20\xcf\x9d\xc5\xe6\x30\xe3\xc2\xd5\xb3\x7f\x00\x53\x6a\x12\x2a\x60\x93\x0c\x12\x35\x45\xf2\x53\xf9\xa5\x34\xd4\x98\x20\x9f\x15\x96\x8b\xff\x0b\x77\x97\x90\x65\x32\x81\x68\xc9\x36\xcf\x61\xab\x99\x25\xcf\x63\x30\x37\x62\x40\x67\x18\x25\xf6\x16\x12\x25\x2d\xde\x5a\x72\x54\xfc\xc6\x10\x79\x73\x72\x4e\x27\x08\x79\xde\x03\xd4\x5a\xe9\x18\xe6\x61\x30\xa3\x1a\xa2\x30\x08\x34\x1a\x17\x82\x5c\xa2\xc9\x84\x0d\x83\xc0\x3b\x5c\x36\x32\x1e\xc0\xeb\x66\x90\x79\xa2\x24\xe3\xa3\x7d\x68\x55\x46\x8a\xf7\x79\x18\xc4\x61\x60\x6f\x7d\x2e\x37\xb8\xb6\x59\xaa\xdd\x3f\x72\x75\xeb\x2a\x8e\xc3\x80\x33\x6f\xf9\x9f\x03\x90\x5c\xb8\xca\x02\x8d\x36\xd3\xd2\x3d\xfa\x20\x61\x90\x87\x41\x03\x57\x57\x6d\x5f\x1a\xd4\xd6\x83\x43\xde\xd3\xe4\x9a\x8e\x5c\x69\xe4\x8a\x0e\x05\xc6\xe4\x18\x19\xcd\x84\x6d\x63\x57\xa5\x3e\x2e\xa6\x2f\x8a\xe3\x30\x98\xcf\xb7\x41\x53\x39\x42\xd8\xfc\xbd\x07\x9b\xcc\x25\xd8\x24\xa7\x1c\x45\x6a\xdc\x2c\x04\xae\xbe\x19\x15\x19\x76\x8d\xc5\x79\x6f\x32\x32\xb0\x3a\x4b\xac\x77\x82\x3c\x7f\x5b\xda\x37\x46\xe4\xd3\x70\xe6\x6c\xfb\xe6\xe7\xc1\xc5\x79\x11\x3a\x08\x86\x19\x5b\x00\xf5\x87\x51\x92\x9c\x51\x6d\xc6\x54\x44\x5b\x3e\x46\xec\x8d\xee\x23\x14\x74\x80\x14\x04\x41\x15\xd3\x43\x45\x06\x78\x1f\x20\xf7\xcc\x1c\x3d\x8c\xa5\xd2\x7a\x4a\x0c\x33\x16\x57\x25\xa2\x30\x58\x97\xf6\xac\x30\x8d\x82\x7d\x24\x99\x96\x81\xda\x7c\x72\xce\xd5\xd2\x60\x15\xa9\xc0\x63\xcb\x19\x48\x65\xfd\x6b\x2e\x84\x9b\x4b\xc8\x73\xc7\xe0\x22\x9a\xcf\x10\xfa\x61\x36\x53\xdc\x64\xa8\xef\x7a\x40\xf5\xc8\x38\x18\xab\xba\x3f\xb8\xd7\x51\x4d\xb0\xfd\x03\xb0\xb7\xe4\xe4\x16\x13\x47\xbc\x1e\x34\xdc\x7a\xf0\x5a\xa3\x89\xdf\x3e\x46\x44\xad\x84\x18\xd2\xe4\x3a\x2a\xa9\x1d\x7b\x5a\xf2\x74\x31\x7d\x1a\x0d\x79\x47\x8d\x2d\xa8\xd9\x4f\xa3\x27\xb9\xdd\x1d\xf2\x1e\x5e\xfd\xe3\x05\x3a\x9b\xa4\x7f\x4c\xfa\x66\x60\x35\x97\x23\xc8\x73\x63\x75\xa2\xe4\x8c\x9c\x2a\x3d\xa1\xb6\x2f\x6d\xe4\x0a\x7a\xb3\x1b\x3b\xcc\x8a\xb9\xf4\xe1\xfa\xc7\xe4\xea\x6e\xea\x1e\x23\x9e\xc6\x0b\x40\xef\xd1\x1f\x0b\xfa\x9f\xa4\x23\xac\xd9\x2f\x50\xde\x5b\x49\xee\x19\x5b\xbc\x8f\xe1\xff\xb0\xbb\x44\x77\x2a\x53\x67\xf6\x51\xf2\x9b\x0c\xbd\x03\x0a\x76\x89\xcc\x97\xb5\xb3\x05\x17\x7b\x17\xf0\x95\xdb\x31\x18\x14\x0c\x34\x32\xd4\x28\x13\x04\xdf\x70\x1d\x07\x99\xd2\x80\x3c\xf5\xf0\xfa\x2a\x57\xa9\xa3\x5a\x21\xae\x08\x8b\x93\xa9\xa0\xb6\xb3\x67\xef\x38\xe8\x50\x5b\x9e\x6e\xb8\x91\x6f\x97\x39\xdb\x7c\x72\xed\xe6\xe3\x34\xa5\x16\x3b\x97\x01\x16\x4d\xa7\xb1\x16\x62\x52\xc4\x09\x82\x87\x96\x0e\x92\x23\x25\xb2\x89\x5c\x5a\x40\xc8\xd3\xda\xf3\xb7\x31\x6a\x8c\x5c\xea\x93\x0f\x9d\x21\xdc\x94\x2e\xb9\xf3\x34\x8e\x6b\xce\x37\xda\xc6\x1a\xbc\x6f\xf7\x97\x0e\xa2\xd6\xed\x66\x09\xaf\x1f\x07\xd7\xa3\x68\xa1\xa7\x7b\x47\x6e\xf7\xb6\x8d\x9c\x07\xfe\x50\xa6\x51\x4c\xfa\xe6\x3c\x13\x62\xd5\x22\x5e\x0a\x70\xca\x18\x26\x16\x97\x5b\xcf\xa5\xfa\x6a\x0e\xcb\x0f\xad\x82\xd6\x4e\xc4\x19\x70\x69\xa3\x2a\x5f\x0c\xff\x7b\x46\x33\x78\x32\xdd\xeb\x13\xad\x3d\x9a\x9a\x72\x69\x4f\x29\x17\x98\xce\x27\x66\xb4\x0f\x6c\x62\xc9\x60\xaa\xb9\xb4\x2c\xda\xf8\xbc\x51\xc4\x2f\x95\xe2\xf3\x06\x44\xaf\x66\x31\x50\xa1\x91\xa6\x77\x6e\xcb\x23\x7d\x75\x60\x15\x50\x48\x39\xf3\x5d\xc4\x42\xe1\x57\xbb\x6d\x14\x33\x9d\x2f\x0d\x31\x5f\x52\x3e\xd7\x61\x91\x9c\xed\x9d\x01\xbc\x64\x03\x72\x31\xa9\x4b\xb9\x5b\xf6\xef\xa1\x7b\x78\xe3\x1f\xb6\xcb\x22\xfb\xa6\xef\x7c\x17\x2d\x9e\x42\x65\xe1\xcc\x17\xae\xb5\x0c\x77\xf6\xb5\x07\xb6\x51\x4f\x2d\xd4\x62\x25\x98\x07\xfc\xde\xff\xd2\x70\xfa\x54\x14\x97\xe7\x5f\x7a\xb0\xaa\xf9\xd0\x99\xd7\xd9\x7e\x75\xb2\x6f\xbc\xb2\x2d\xf5\xc8\x1a\x8c\x96\xac\x38\x35\xd9\xd6\xc8\xa0\x80\xd9\xf8\x8d\x3e\x7a\x4d\xe3\x12\x86\xca\x8e\xe1\x2b\xbd\x33\xa4\xd6\x99\x46\x1a\x74\x79\xda\x69\x9a\x30\x06\xc1\x4b\x2c\xfa\x6e\xa2\x5e\xbc\x28\x4f\xbf\x9b\x50\xae\xad\x93\x6b\xca\x64\xf8\xd7\x9a\xc7\x8b\xbd\xb3\x6a\x1e\xa7\x15\x90\xef\xcb\xba\x5e\x64\x62\xa7\xe4\x42\x47\xf1\xda\x62\xda\x38\x8b\x7c\x2f\x8a\xac\xb9\x35\xa8\xf9\xe1\xf4\x7d\xda\x2b\x9a\xde\x33\x45\xbe\x0a\xd6\xa4\xcb\x37\xb1\xe5\x69\xb2\x14\xe0\xad\xaa\xf3\x4f\x9e\x0f\x1f\x4b\xf2\x3d\x34\xfe\x5b\x25\x5e\x49\x04\xc5\xe0\xbe\xd2\xbf\x9a\xad\xa5\xf3\xd7\x78\x67\x56\x1b\x41\xb5\x1d\xc8\x5b\x27\xe0\xc5\xf1\x64\x21\x11\x95\xda\x2c\x68\xdf\x38\x86\x15\x28\x60\xe3\x30\x58\x1d\xcc\x0e\xad\xe2\xd1\xea\xe5\x7c\xda\xfd\xb2\xf2\xd6\xad\x3a\xf4\x07\x75\x7d\xcd\xe3\x7b\x50\x76\x8d\x67\x25\x0f\x3b\x04\xaf\x7b\xcf\xf1\xb7\x56\x80\x75\x77\xfb\x1d\xba\x71\x0f\xf6\x97\x81\xe4\x31\x44\x7e\xd8\x61\xe8\x21\x78\x6a\x2e\xfd\xdb\x36\xff\xa9\x6d\xb3\x9a\xe3\xd6\xdd\xdc\xd2\x84\x1f\xa9\xc9\x84\xdb\xe8\xf1\x7b\xb6\xea\xc2\xb7\x7c\xd7\xbe\x0d\xeb\x39\xab\xb0\xb8\x8e\x2f\x93\x3c\x7e\x33\xdf\xdc\xe3\x54\x37\x5e\x8f\xf4\xf1\x07\x9b\x78\xb9\xb1\xe9\x20\xcd\x53\x94\x59\x86\xa4\xae\xfb\xcf\x00\x00\x00\xff\xff\x6f\x02\x81\xbd\x15\x19\x00\x00")
+var _templateDialectSqlCreateTmpl = []byte("\x1f\x8b\x08\x00\x00\x00\x00\x00\x00\xff\xec\x58\xdf\x53\xdb\xb8\x16\x7e\xb6\xff\x8a\x73\x19\xda\xb1\x99\x20\x28\x6f\x97\x5e\xee\x0c\xcb\x8f\x99\xec\x16\x68\x09\xdd\x7d\x68\x3b\x3b\x8a\x7d\x94\x68\x51\xa4\x20\xc9\x29\x4c\xc6\xff\xfb\x8e\x64\x3b\x76\x8c\x81\x90\x76\xca\xee\xce\xf2\x42\x6c\x9f\x5f\xfa\xf4\xe9\x7c\x92\xe6\xf3\x9d\xad\xf0\x48\x4d\xef\x34\x1f\x8d\x2d\xec\xed\xbe\xf9\xef\xf6\x54\xa3\x41\x69\xe1\x94\x26\x38\x54\xea\x1a\xfa\x32\x21\x70\x28\x04\x78\x23\x03\xee\xbb\x9e\x61\x4a\xc2\xab\x31\x37\x60\x54\xa6\x13\x84\x44\xa5\x08\xdc\x80\xe0\x09\x4a\x83\x29\x64\x32\x45\x0d\x76\x8c\x70\x38\xa5\xc9\x18\x61\x8f\xec\x56\x5f\x81\xa9\x4c\xa6\x21\x97\xfe\xfb\xbb\xfe\xd1\xc9\xf9\xe0\x04\x18\x17\x08\xe5\x3b\xad\x94\x85\x94\x6b\x4c\xac\xd2\x77\xa0\x18\xd8\x46\x32\xab\x11\x49\xb8\xb5\x93\xe7\x61\x38\x9f\x43\x8a\x8c\x4b\x84\x8d\x94\x53\x81\x89\xdd\x31\x37\x62\x27\xd1\x48\x2d\x6e\x40\x9e\x3b\x8b\xcd\x61\xc6\x85\xab\x67\xff\x00\xa6\xd4\x24\x54\xc0\x26\x19\x24\x6a\x8a\xe4\xa7\xf2\x4b\x69\xa8\x31\x41\x3e\x2b\x2c\x17\xbf\x17\xee\x2e\x21\xcb\x64\x02\xd1\x92\x6d\x9e\xc3\x56\x33\x4b\x9e\xc7\x60\x6e\xc4\x80\xce\x30\x4a\xec\x2d\x24\x4a\x5a\xbc\xb5\xe4\xa8\xf8\x1f\x43\xe4\xcd\xc9\x39\x9d\x20\xe4\x79\x0f\x50\x6b\xa5\x63\x98\x87\xc1\x8c\x6a\x88\xc2\x20\xd0\x68\x5c\x08\x72\x89\x26\x13\x36\x0c\x02\xef\x70\xd9\xc8\x78\x00\xaf\x9b\x41\xe6\x89\x92\x8c\x8f\xf6\xa1\x55\x19\x29\xde\xe7\x61\x10\x87\x81\xbd\xf5\xb9\xdc\xe0\xda\x66\xa9\x76\xbf\xc8\xd5\xad\xab\x38\x0e\x03\xce\xbc\xe5\x7f\x0e\x40\x72\xe1\x2a\x0b\x34\xda\x4c\x4b\xf7\xe8\x83\x84\x41\x1e\x06\x0d\x5c\x5d\xb5\xc7\xc5\x0c\xb4\xd1\xa9\x82\x57\x9f\xe3\x98\x84\x41\xd0\x97\x06\x75\x61\x4b\xde\xd3\xe4\x9a\x8e\xdc\x38\xc8\x15\x1d\x0a\xf4\x06\xc7\xc8\x68\x26\x6c\x14\x87\xc1\x7c\xbe\x0d\x9a\xca\x11\xc2\xe6\xef\x3d\xd8\x64\x2e\xe1\x26\x39\xe5\x28\x52\xe3\x66\x25\x70\xf5\xce\xa8\xc8\xb0\x6b\x6c\xce\x7b\x93\x91\x81\xd5\x59\x62\xbd\x13\xe4\xf9\xdb\xd2\xbe\x31\x42\x9f\x86\x33\x67\xdb\x37\x3f\x0f\x2e\xce\x8b\xd0\x41\x30\xcc\xd8\x02\xb8\x3f\x8c\x92\xe4\x8c\x6a\x33\xa6\x22\xda\xf2\x31\x62\x6f\x74\x1f\xb1\xa0\x03\xb4\x20\x08\xaa\x98\x1e\x3a\x32\xc0\xfb\x18\xb8\x67\xe6\xe8\x62\x2c\x95\xd6\x53\x64\x98\xb1\xb8\x2a\x11\x85\xc1\xba\xb4\x67\x85\x69\x14\xec\x23\xc9\xb4\x0c\xd4\xe6\x97\x73\xae\x96\x0a\xab\x48\x06\x1e\x5b\xce\x40\x2a\xeb\x5f\x73\x21\xdc\x74\x41\x9e\x3b\x46\x17\xd1\x7c\x86\xd0\x0f\xb3\x99\xe2\x26\x43\x7d\xd7\x03\xaa\x47\xc6\xc1\x58\xd5\xfd\xc1\xbd\x8e\x6a\xc2\xed\x1f\x80\xbd\x25\x27\xb7\x98\x38\x22\xf6\xa0\xe1\xd6\x83\xd7\x1a\x4d\xfc\xf6\x31\x62\x6a\x25\xc4\x90\x26\xd7\x51\x49\xf5\xd8\xd3\x94\xa7\x8b\xe9\xd3\x68\xc8\x3b\x6a\x6c\xc1\xbe\x7e\x1a\x3d\xc9\xf5\xee\x90\xf7\xf0\xea\x1f\x2f\xd0\xd9\x24\xfd\x63\xd2\x37\x03\xab\xb9\x1c\x41\x9e\x1b\xab\x13\x25\x67\xe4\x54\xe9\x09\xb5\x7d\x69\x23\x57\xd0\x9b\xdd\xd8\x61\x56\xcc\xa5\x0f\xd7\x3f\x26\x57\x77\x53\xf7\x18\xf1\x34\x5e\x00\x7a\x8f\xfe\x58\xd0\xff\x24\x1d\x61\xcd\x7e\x81\xf2\xde\xba\x73\xcf\xd8\xe2\x7d\x0c\xff\x87\xdd\x25\xba\x53\x99\x3a\xb3\x8f\x92\xdf\x64\xe8\x1d\x50\xb0\x4b\x64\xbe\xac\x9d\x2d\xb8\xd8\xbb\x80\xaf\xdc\x8e\xc1\xa0\x60\xa0\x91\xa1\x46\x99\x20\xf8\x06\xec\x38\xc8\x94\x06\xe4\xa9\x87\xd7\x57\xb9\x4a\x1d\xd5\x0a\x71\x45\x58\x9c\x4c\x05\xb5\x9d\x3d\x7c\xc7\x41\x87\xda\xf2\x74\xc3\x8d\x7c\xbb\xcc\xd9\xe6\x93\x6b\x3f\x1f\xa7\x29\xb5\xd8\xb9\x0c\xb0\xe8\x2b\x8d\xb5\xe0\x5b\x8c\xff\x7b\x68\xe9\x20\x39\x52\x22\x9b\xc8\xa5\x05\x84\x3c\xad\x3d\x7f\x1b\xa3\xc6\xc8\xa5\x3e\xf9\xd0\x19\xc2\x4d\xe9\x92\x3b\x4f\xe3\xb8\xe6\x7c\xa3\x6d\xac\xc1\xfb\x76\x7f\xe9\x20\x6a\xdd\x6e\x96\xf0\xfa\x71\x70\x3d\x8a\x16\x7a\xba\x77\xe4\x76\x6f\xdb\xc8\x79\xe0\x0f\x65\x1a\xc5\xa4\x6f\xce\x33\x21\x56\x2d\xe2\xa5\x00\xa7\x8c\x61\x62\x71\xb9\xf5\x5c\xaa\xaf\xe6\xb0\xfc\xd0\x2a\x68\xed\x44\x9c\x01\x97\x36\xaa\xf2\xc5\xf0\xbf\x67\x34\x83\x27\xd3\xbd\x3e\xd1\xda\xa3\xa9\x29\x97\xf6\x94\x72\x81\xe9\x7c\x62\x46\xfb\xc0\x26\x96\x0c\xa6\x9a\x4b\xcb\xa2\x8d\xcf\x1b\x45\xfc\x52\x29\x3e\x6f\x40\xf4\x6a\x16\x03\x15\x1a\x69\x7a\xe7\xb6\x40\xd2\x57\x07\x56\x01\x85\x94\x33\xdf\x45\x2c\x14\x7e\xb5\xdb\x46\x31\xd3\xf9\xd2\x10\xf3\x25\xe5\x73\x1d\x16\xc9\xd9\xde\x19\xc0\x4b\x36\x20\x17\x93\xba\x94\xbb\x65\xff\x1e\xba\x87\x37\xfe\x61\xbb\x2c\xb2\x6f\xfa\xce\x77\xd1\xe2\x29\x54\x16\xce\x7c\xe1\x5a\xcb\x70\x67\x5f\x7b\x60\xa7\xf4\xd4\x42\x2d\x56\x82\x79\xc0\xef\xfd\x2f\x0d\xa7\x4f\x45\x71\x79\xfe\xa5\x07\xab\x9a\x0f\x9d\x79\x9d\xed\x57\x27\xfb\xc6\x2b\xdb\x52\x8f\xac\xc1\x68\xc9\x8a\x53\x93\x6d\x8d\x0c\x0a\x98\x8d\xdf\xf8\xa3\xd7\x34\x2e\x61\xa8\xec\x18\xbe\xd2\x3b\x43\x6a\x9d\x69\xa4\x41\x97\xa7\x9d\xa6\x09\x63\x10\xbc\xc4\xa2\xef\x26\xea\xc5\x8b\xf2\xf4\xbb\x09\xe5\xda\x3a\xb9\xa6\x4c\x86\x7f\xad\x79\xbc\xd8\x3b\xab\xe6\x71\x5a\x01\xf9\xbe\xac\xeb\x45\x26\x76\x4a\x2e\x74\x14\xaf\x2d\xa6\x8d\xb3\xc8\xf7\xa2\xc8\x9a\x5b\x83\x9a\x1f\x4e\xdf\xa7\xbd\xa2\xe9\x3d\x53\xe4\xab\x60\x4d\xba\x7c\x13\x5b\x9e\x26\x4b\x01\xde\xaa\x3a\xff\xe4\xf9\xf0\xb1\x24\xdf\x43\xe3\xbf\x55\xe2\x95\x44\x50\x0c\xee\x2b\xfd\xab\xd9\x5a\x3a\x7f\x8d\x77\x66\xb5\x11\x54\xdb\x81\xbc\x75\x02\x5e\x1c\x4f\x16\x12\x51\xa9\xcd\x82\xf6\x8d\x63\x58\x81\x02\x36\x0e\x83\xd5\xc1\xec\xd0\x2a\x1e\xad\x5e\xce\xa7\xdd\x2f\x2b\x6f\xdd\xaa\x43\x7f\x50\xd7\xd7\x3c\xbe\x07\x65\xd7\x78\x56\xf2\xb0\x43\xf0\xba\xf7\x1c\x7f\x6b\x05\x58\x77\xb7\xdf\xa1\x1b\xf7\x60\x7f\x19\x48\x1e\x43\xe4\x87\x1d\x86\x1e\x82\xa7\xe6\xd2\xbf\x6d\xf3\x9f\xda\x36\xab\x39\x6e\xdd\xcd\x2d\x4d\xf8\x91\x9a\x4c\xb8\x8d\x1e\xbf\x67\xab\x2e\x80\xcb\x77\xed\xdb\xb0\x9e\xb3\x0a\x8b\xeb\xf9\x32\xc9\xe3\x37\xf5\xcd\x3d\x4e\x75\xe3\xf5\x48\x1f\x7f\xb0\x89\x97\x1b\x9b\x0e\xd2\x3c\x45\x99\x65\x48\xea\xba\xff\x0c\x00\x00\xff\xff\xb6\xcb\x6e\xfb\x25\x19\x00\x00")
 
 func templateDialectSqlCreateTmplBytes() ([]byte, error) {
 	return bindataRead(
@@ -574,7 +574,7 @@ func templateDialectSqlCreateTmpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "template/dialect/sql/create.tmpl", size: 6421, mode: os.FileMode(420), modTime: time.Unix(1569318665, 0)}
+	info := bindataFileInfo{name: "template/dialect/sql/create.tmpl", size: 6437, mode: os.FileMode(420), modTime: time.Unix(1570914948, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -594,7 +594,7 @@ func templateDialectSqlDecodeTmpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "template/dialect/sql/decode.tmpl", size: 2142, mode: os.FileMode(420), modTime: time.Unix(1570346843, 0)}
+	info := bindataFileInfo{name: "template/dialect/sql/decode.tmpl", size: 2142, mode: os.FileMode(420), modTime: time.Unix(1570187959, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -614,7 +614,7 @@ func templateDialectSqlDeleteTmpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "template/dialect/sql/delete.tmpl", size: 828, mode: os.FileMode(420), modTime: time.Unix(1568794256, 0)}
+	info := bindataFileInfo{name: "template/dialect/sql/delete.tmpl", size: 828, mode: os.FileMode(420), modTime: time.Unix(1568645716, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -634,7 +634,7 @@ func templateDialectSqlErrorsTmpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "template/dialect/sql/errors.tmpl", size: 967, mode: os.FileMode(420), modTime: time.Unix(1567406598, 0)}
+	info := bindataFileInfo{name: "template/dialect/sql/errors.tmpl", size: 967, mode: os.FileMode(420), modTime: time.Unix(1567330602, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -654,7 +654,7 @@ func templateDialectSqlGroupTmpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "template/dialect/sql/group.tmpl", size: 1031, mode: os.FileMode(420), modTime: time.Unix(1567406598, 0)}
+	info := bindataFileInfo{name: "template/dialect/sql/group.tmpl", size: 1031, mode: os.FileMode(420), modTime: time.Unix(1567330605, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -674,7 +674,7 @@ func templateDialectSqlMetaTmpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "template/dialect/sql/meta.tmpl", size: 1782, mode: os.FileMode(420), modTime: time.Unix(1567406598, 0)}
+	info := bindataFileInfo{name: "template/dialect/sql/meta.tmpl", size: 1782, mode: os.FileMode(420), modTime: time.Unix(1567330610, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -694,7 +694,7 @@ func templateDialectSqlOpenTmpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "template/dialect/sql/open.tmpl", size: 389, mode: os.FileMode(420), modTime: time.Unix(1570020385, 0)}
+	info := bindataFileInfo{name: "template/dialect/sql/open.tmpl", size: 389, mode: os.FileMode(420), modTime: time.Unix(1570008718, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -714,7 +714,7 @@ func templateDialectSqlPredicateTmpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "template/dialect/sql/predicate.tmpl", size: 4526, mode: os.FileMode(420), modTime: time.Unix(1567406598, 0)}
+	info := bindataFileInfo{name: "template/dialect/sql/predicate.tmpl", size: 4526, mode: os.FileMode(420), modTime: time.Unix(1567330614, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -734,7 +734,7 @@ func templateDialectSqlQueryTmpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "template/dialect/sql/query.tmpl", size: 6382, mode: os.FileMode(420), modTime: time.Unix(1570346843, 0)}
+	info := bindataFileInfo{name: "template/dialect/sql/query.tmpl", size: 6382, mode: os.FileMode(420), modTime: time.Unix(1570094421, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -754,7 +754,7 @@ func templateDialectSqlSelectTmpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "template/dialect/sql/select.tmpl", size: 809, mode: os.FileMode(420), modTime: time.Unix(1568019515, 0)}
+	info := bindataFileInfo{name: "template/dialect/sql/select.tmpl", size: 809, mode: os.FileMode(420), modTime: time.Unix(1567539807, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -774,7 +774,7 @@ func templateDialectSqlUpdateTmpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "template/dialect/sql/update.tmpl", size: 12705, mode: os.FileMode(420), modTime: time.Unix(1570346843, 0)}
+	info := bindataFileInfo{name: "template/dialect/sql/update.tmpl", size: 12705, mode: os.FileMode(420), modTime: time.Unix(1570107181, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -794,7 +794,7 @@ func templateEntTmpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "template/ent.tmpl", size: 4199, mode: os.FileMode(420), modTime: time.Unix(1570458335, 0)}
+	info := bindataFileInfo{name: "template/ent.tmpl", size: 4199, mode: os.FileMode(420), modTime: time.Unix(1570646976, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -814,7 +814,7 @@ func templateExampleTmpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "template/example.tmpl", size: 2425, mode: os.FileMode(420), modTime: time.Unix(1567406598, 0)}
+	info := bindataFileInfo{name: "template/example.tmpl", size: 2425, mode: os.FileMode(420), modTime: time.Unix(1567330554, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -834,7 +834,7 @@ func templateHeaderTmpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "template/header.tmpl", size: 436, mode: os.FileMode(420), modTime: time.Unix(1570458334, 0)}
+	info := bindataFileInfo{name: "template/header.tmpl", size: 436, mode: os.FileMode(420), modTime: time.Unix(1570451141, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -854,7 +854,7 @@ func templateImportTmpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "template/import.tmpl", size: 984, mode: os.FileMode(420), modTime: time.Unix(1568897494, 0)}
+	info := bindataFileInfo{name: "template/import.tmpl", size: 984, mode: os.FileMode(420), modTime: time.Unix(1568822311, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -874,7 +874,7 @@ func templateMetaTmpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "template/meta.tmpl", size: 4291, mode: os.FileMode(420), modTime: time.Unix(1570346843, 0)}
+	info := bindataFileInfo{name: "template/meta.tmpl", size: 4291, mode: os.FileMode(420), modTime: time.Unix(1570033406, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -894,7 +894,7 @@ func templateMigrateMigrateTmpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "template/migrate/migrate.tmpl", size: 2450, mode: os.FileMode(420), modTime: time.Unix(1568019515, 0)}
+	info := bindataFileInfo{name: "template/migrate/migrate.tmpl", size: 2450, mode: os.FileMode(420), modTime: time.Unix(1567952288, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -914,7 +914,7 @@ func templateMigrateSchemaTmpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "template/migrate/schema.tmpl", size: 3755, mode: os.FileMode(420), modTime: time.Unix(1570346843, 0)}
+	info := bindataFileInfo{name: "template/migrate/schema.tmpl", size: 3755, mode: os.FileMode(420), modTime: time.Unix(1570019529, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -934,7 +934,7 @@ func templatePredicateTmpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "template/predicate.tmpl", size: 1213, mode: os.FileMode(420), modTime: time.Unix(1567406598, 0)}
+	info := bindataFileInfo{name: "template/predicate.tmpl", size: 1213, mode: os.FileMode(420), modTime: time.Unix(1567330539, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -954,7 +954,7 @@ func templateTxTmpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "template/tx.tmpl", size: 3382, mode: os.FileMode(420), modTime: time.Unix(1567406598, 0)}
+	info := bindataFileInfo{name: "template/tx.tmpl", size: 3382, mode: os.FileMode(420), modTime: time.Unix(1567330536, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -974,7 +974,7 @@ func templateWhereTmpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "template/where.tmpl", size: 5353, mode: os.FileMode(420), modTime: time.Unix(1570346843, 0)}
+	info := bindataFileInfo{name: "template/where.tmpl", size: 5353, mode: os.FileMode(420), modTime: time.Unix(1570012859, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }

--- a/entc/gen/template/dialect/sql/create.tmpl
+++ b/entc/gen/template/dialect/sql/create.tmpl
@@ -17,7 +17,9 @@ func ({{ $receiver }} *{{ $builder }}) sqlSave(ctx context.Context) (*{{ $.Name 
 	if err != nil {
 		return nil, err
 	}
-	builder := sql.Insert({{ $.Package }}.Table).Default({{ $receiver }}.driver.Dialect())
+	builder := sql.Dialect({{ $receiver }}.driver.Dialect()).
+		Insert({{ $.Package }}.Table).
+		Default()
 	{{- range $_, $f := $.Fields }}
 		if value := {{ $receiver }}.{{- $f.StructField }}; value != nil {
 			{{- if $f.IsJSON }}

--- a/entc/integration/config/ent/user_create.go
+++ b/entc/integration/config/ent/user_create.go
@@ -41,7 +41,9 @@ func (uc *UserCreate) sqlSave(ctx context.Context) (*User, error) {
 	if err != nil {
 		return nil, err
 	}
-	builder := sql.Insert(user.Table).Default(uc.driver.Dialect())
+	builder := sql.Dialect(uc.driver.Dialect()).
+		Insert(user.Table).
+		Default()
 	query, args := builder.Query()
 	if err := tx.Exec(ctx, query, args, &res); err != nil {
 		return nil, rollback(tx, err)

--- a/entc/integration/ent/card_create.go
+++ b/entc/integration/ent/card_create.go
@@ -136,7 +136,9 @@ func (cc *CardCreate) sqlSave(ctx context.Context) (*Card, error) {
 	if err != nil {
 		return nil, err
 	}
-	builder := sql.Insert(card.Table).Default(cc.driver.Dialect())
+	builder := sql.Dialect(cc.driver.Dialect()).
+		Insert(card.Table).
+		Default()
 	if value := cc.created_at; value != nil {
 		builder.Set(card.FieldCreatedAt, *value)
 		c.CreatedAt = *value

--- a/entc/integration/ent/comment_create.go
+++ b/entc/integration/ent/comment_create.go
@@ -91,7 +91,9 @@ func (cc *CommentCreate) sqlSave(ctx context.Context) (*Comment, error) {
 	if err != nil {
 		return nil, err
 	}
-	builder := sql.Insert(comment.Table).Default(cc.driver.Dialect())
+	builder := sql.Dialect(cc.driver.Dialect()).
+		Insert(comment.Table).
+		Default()
 	if value := cc.unique_int; value != nil {
 		builder.Set(comment.FieldUniqueInt, *value)
 		c.UniqueInt = *value

--- a/entc/integration/ent/fieldtype_create.go
+++ b/entc/integration/ent/fieldtype_create.go
@@ -295,7 +295,9 @@ func (ftc *FieldTypeCreate) sqlSave(ctx context.Context) (*FieldType, error) {
 	if err != nil {
 		return nil, err
 	}
-	builder := sql.Insert(fieldtype.Table).Default(ftc.driver.Dialect())
+	builder := sql.Dialect(ftc.driver.Dialect()).
+		Insert(fieldtype.Table).
+		Default()
 	if value := ftc.int; value != nil {
 		builder.Set(fieldtype.FieldInt, *value)
 		ft.Int = *value

--- a/entc/integration/ent/file_create.go
+++ b/entc/integration/ent/file_create.go
@@ -171,7 +171,9 @@ func (fc *FileCreate) sqlSave(ctx context.Context) (*File, error) {
 	if err != nil {
 		return nil, err
 	}
-	builder := sql.Insert(file.Table).Default(fc.driver.Dialect())
+	builder := sql.Dialect(fc.driver.Dialect()).
+		Insert(file.Table).
+		Default()
 	if value := fc.size; value != nil {
 		builder.Set(file.FieldSize, *value)
 		f.Size = *value

--- a/entc/integration/ent/filetype_create.go
+++ b/entc/integration/ent/filetype_create.go
@@ -89,7 +89,9 @@ func (ftc *FileTypeCreate) sqlSave(ctx context.Context) (*FileType, error) {
 	if err != nil {
 		return nil, err
 	}
-	builder := sql.Insert(filetype.Table).Default(ftc.driver.Dialect())
+	builder := sql.Dialect(ftc.driver.Dialect()).
+		Insert(filetype.Table).
+		Default()
 	if value := ftc.name; value != nil {
 		builder.Set(filetype.FieldName, *value)
 		ft.Name = *value

--- a/entc/integration/ent/group_create.go
+++ b/entc/integration/ent/group_create.go
@@ -228,7 +228,9 @@ func (gc *GroupCreate) sqlSave(ctx context.Context) (*Group, error) {
 	if err != nil {
 		return nil, err
 	}
-	builder := sql.Insert(group.Table).Default(gc.driver.Dialect())
+	builder := sql.Dialect(gc.driver.Dialect()).
+		Insert(group.Table).
+		Default()
 	if value := gc.active; value != nil {
 		builder.Set(group.FieldActive, *value)
 		gr.Active = *value

--- a/entc/integration/ent/groupinfo_create.go
+++ b/entc/integration/ent/groupinfo_create.go
@@ -108,7 +108,9 @@ func (gic *GroupInfoCreate) sqlSave(ctx context.Context) (*GroupInfo, error) {
 	if err != nil {
 		return nil, err
 	}
-	builder := sql.Insert(groupinfo.Table).Default(gic.driver.Dialect())
+	builder := sql.Dialect(gic.driver.Dialect()).
+		Insert(groupinfo.Table).
+		Default()
 	if value := gic.desc; value != nil {
 		builder.Set(groupinfo.FieldDesc, *value)
 		gi.Desc = *value

--- a/entc/integration/ent/item_create.go
+++ b/entc/integration/ent/item_create.go
@@ -54,7 +54,9 @@ func (ic *ItemCreate) sqlSave(ctx context.Context) (*Item, error) {
 	if err != nil {
 		return nil, err
 	}
-	builder := sql.Insert(item.Table).Default(ic.driver.Dialect())
+	builder := sql.Dialect(ic.driver.Dialect()).
+		Insert(item.Table).
+		Default()
 	query, args := builder.Query()
 	if err := tx.Exec(ctx, query, args, &res); err != nil {
 		return nil, rollback(tx, err)

--- a/entc/integration/ent/node_create.go
+++ b/entc/integration/ent/node_create.go
@@ -124,7 +124,9 @@ func (nc *NodeCreate) sqlSave(ctx context.Context) (*Node, error) {
 	if err != nil {
 		return nil, err
 	}
-	builder := sql.Insert(node.Table).Default(nc.driver.Dialect())
+	builder := sql.Dialect(nc.driver.Dialect()).
+		Insert(node.Table).
+		Default()
 	if value := nc.value; value != nil {
 		builder.Set(node.FieldValue, *value)
 		n.Value = *value

--- a/entc/integration/ent/pet_create.go
+++ b/entc/integration/ent/pet_create.go
@@ -120,7 +120,9 @@ func (pc *PetCreate) sqlSave(ctx context.Context) (*Pet, error) {
 	if err != nil {
 		return nil, err
 	}
-	builder := sql.Insert(pet.Table).Default(pc.driver.Dialect())
+	builder := sql.Dialect(pc.driver.Dialect()).
+		Insert(pet.Table).
+		Default()
 	if value := pc.name; value != nil {
 		builder.Set(pet.FieldName, *value)
 		pe.Name = *value

--- a/entc/integration/ent/user_create.go
+++ b/entc/integration/ent/user_create.go
@@ -395,7 +395,9 @@ func (uc *UserCreate) sqlSave(ctx context.Context) (*User, error) {
 	if err != nil {
 		return nil, err
 	}
-	builder := sql.Insert(user.Table).Default(uc.driver.Dialect())
+	builder := sql.Dialect(uc.driver.Dialect()).
+		Insert(user.Table).
+		Default()
 	if value := uc.age; value != nil {
 		builder.Set(user.FieldAge, *value)
 		u.Age = *value

--- a/entc/integration/idtype/ent/user_create.go
+++ b/entc/integration/idtype/ent/user_create.go
@@ -121,7 +121,9 @@ func (uc *UserCreate) sqlSave(ctx context.Context) (*User, error) {
 	if err != nil {
 		return nil, err
 	}
-	builder := sql.Insert(user.Table).Default(uc.driver.Dialect())
+	builder := sql.Dialect(uc.driver.Dialect()).
+		Insert(user.Table).
+		Default()
 	if value := uc.name; value != nil {
 		builder.Set(user.FieldName, *value)
 		u.Name = *value

--- a/entc/integration/json/ent/user_create.go
+++ b/entc/integration/json/ent/user_create.go
@@ -86,7 +86,9 @@ func (uc *UserCreate) sqlSave(ctx context.Context) (*User, error) {
 	if err != nil {
 		return nil, err
 	}
-	builder := sql.Insert(user.Table).Default(uc.driver.Dialect())
+	builder := sql.Dialect(uc.driver.Dialect()).
+		Insert(user.Table).
+		Default()
 	if value := uc.url; value != nil {
 		buf, err := json.Marshal(*value)
 		if err != nil {

--- a/entc/integration/migrate/entv1/user_create.go
+++ b/entc/integration/migrate/entv1/user_create.go
@@ -123,7 +123,9 @@ func (uc *UserCreate) sqlSave(ctx context.Context) (*User, error) {
 	if err != nil {
 		return nil, err
 	}
-	builder := sql.Insert(user.Table).Default(uc.driver.Dialect())
+	builder := sql.Dialect(uc.driver.Dialect()).
+		Insert(user.Table).
+		Default()
 	if value := uc.age; value != nil {
 		builder.Set(user.FieldAge, *value)
 		u.Age = *value

--- a/entc/integration/migrate/entv2/group_create.go
+++ b/entc/integration/migrate/entv2/group_create.go
@@ -41,7 +41,9 @@ func (gc *GroupCreate) sqlSave(ctx context.Context) (*Group, error) {
 	if err != nil {
 		return nil, err
 	}
-	builder := sql.Insert(group.Table).Default(gc.driver.Dialect())
+	builder := sql.Dialect(gc.driver.Dialect()).
+		Insert(group.Table).
+		Default()
 	query, args := builder.Query()
 	if err := tx.Exec(ctx, query, args, &res); err != nil {
 		return nil, rollback(tx, err)

--- a/entc/integration/migrate/entv2/pet_create.go
+++ b/entc/integration/migrate/entv2/pet_create.go
@@ -41,7 +41,9 @@ func (pc *PetCreate) sqlSave(ctx context.Context) (*Pet, error) {
 	if err != nil {
 		return nil, err
 	}
-	builder := sql.Insert(pet.Table).Default(pc.driver.Dialect())
+	builder := sql.Dialect(pc.driver.Dialect()).
+		Insert(pet.Table).
+		Default()
 	query, args := builder.Query()
 	if err := tx.Exec(ctx, query, args, &res); err != nil {
 		return nil, rollback(tx, err)

--- a/entc/integration/migrate/entv2/user_create.go
+++ b/entc/integration/migrate/entv2/user_create.go
@@ -145,7 +145,9 @@ func (uc *UserCreate) sqlSave(ctx context.Context) (*User, error) {
 	if err != nil {
 		return nil, err
 	}
-	builder := sql.Insert(user.Table).Default(uc.driver.Dialect())
+	builder := sql.Dialect(uc.driver.Dialect()).
+		Insert(user.Table).
+		Default()
 	if value := uc.age; value != nil {
 		builder.Set(user.FieldAge, *value)
 		u.Age = *value

--- a/entc/integration/template/ent/group_create.go
+++ b/entc/integration/template/ent/group_create.go
@@ -52,7 +52,9 @@ func (gc *GroupCreate) sqlSave(ctx context.Context) (*Group, error) {
 	if err != nil {
 		return nil, err
 	}
-	builder := sql.Insert(group.Table).Default(gc.driver.Dialect())
+	builder := sql.Dialect(gc.driver.Dialect()).
+		Insert(group.Table).
+		Default()
 	if value := gc.max_users; value != nil {
 		builder.Set(group.FieldMaxUsers, *value)
 		gr.MaxUsers = *value

--- a/entc/integration/template/ent/pet_create.go
+++ b/entc/integration/template/ent/pet_create.go
@@ -94,7 +94,9 @@ func (pc *PetCreate) sqlSave(ctx context.Context) (*Pet, error) {
 	if err != nil {
 		return nil, err
 	}
-	builder := sql.Insert(pet.Table).Default(pc.driver.Dialect())
+	builder := sql.Dialect(pc.driver.Dialect()).
+		Insert(pet.Table).
+		Default()
 	if value := pc.age; value != nil {
 		builder.Set(pet.FieldAge, *value)
 		pe.Age = *value

--- a/entc/integration/template/ent/user_create.go
+++ b/entc/integration/template/ent/user_create.go
@@ -96,7 +96,9 @@ func (uc *UserCreate) sqlSave(ctx context.Context) (*User, error) {
 	if err != nil {
 		return nil, err
 	}
-	builder := sql.Insert(user.Table).Default(uc.driver.Dialect())
+	builder := sql.Dialect(uc.driver.Dialect()).
+		Insert(user.Table).
+		Default()
 	if value := uc.name; value != nil {
 		builder.Set(user.FieldName, *value)
 		u.Name = *value

--- a/entc/load/internal/bindata.go
+++ b/entc/load/internal/bindata.go
@@ -93,7 +93,7 @@ func templateMainTmpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "template/main.tmpl", size: 843, mode: os.FileMode(420), modTime: time.Unix(1567406598, 0)}
+	info := bindataFileInfo{name: "template/main.tmpl", size: 843, mode: os.FileMode(420), modTime: time.Unix(1567330508, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -113,7 +113,7 @@ func schemaGo() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "schema.go", size: 7340, mode: os.FileMode(420), modTime: time.Unix(1570458335, 0)}
+	info := bindataFileInfo{name: "schema.go", size: 7340, mode: os.FileMode(420), modTime: time.Unix(1570646976, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }

--- a/entc/load/load.go
+++ b/entc/load/load.go
@@ -103,6 +103,9 @@ func (c *Config) load() (string, error) {
 	if err != nil {
 		return "", err
 	}
+	if len(pkgs) == 0 {
+		return "", fmt.Errorf("missing package information for: %s", c.Path)
+	}
 	entPkg, pkg := pkgs[0], pkgs[1]
 	if pkgs[0].PkgPath != entInterface.PkgPath() {
 		entPkg, pkg = pkgs[1], pkgs[0]

--- a/examples/edgeindex/ent/city_create.go
+++ b/examples/edgeindex/ent/city_create.go
@@ -75,7 +75,9 @@ func (cc *CityCreate) sqlSave(ctx context.Context) (*City, error) {
 	if err != nil {
 		return nil, err
 	}
-	builder := sql.Insert(city.Table).Default(cc.driver.Dialect())
+	builder := sql.Dialect(cc.driver.Dialect()).
+		Insert(city.Table).
+		Default()
 	if value := cc.name; value != nil {
 		builder.Set(city.FieldName, *value)
 		c.Name = *value

--- a/examples/edgeindex/ent/street_create.go
+++ b/examples/edgeindex/ent/street_create.go
@@ -78,7 +78,9 @@ func (sc *StreetCreate) sqlSave(ctx context.Context) (*Street, error) {
 	if err != nil {
 		return nil, err
 	}
-	builder := sql.Insert(street.Table).Default(sc.driver.Dialect())
+	builder := sql.Dialect(sc.driver.Dialect()).
+		Insert(street.Table).
+		Default()
 	if value := sc.name; value != nil {
 		builder.Set(street.FieldName, *value)
 		s.Name = *value

--- a/examples/entcpkg/ent/user_create.go
+++ b/examples/entcpkg/ent/user_create.go
@@ -41,7 +41,9 @@ func (uc *UserCreate) sqlSave(ctx context.Context) (*User, error) {
 	if err != nil {
 		return nil, err
 	}
-	builder := sql.Insert(user.Table).Default(uc.driver.Dialect())
+	builder := sql.Dialect(uc.driver.Dialect()).
+		Insert(user.Table).
+		Default()
 	query, args := builder.Query()
 	if err := tx.Exec(ctx, query, args, &res); err != nil {
 		return nil, rollback(tx, err)

--- a/examples/m2m2types/ent/group_create.go
+++ b/examples/m2m2types/ent/group_create.go
@@ -73,7 +73,9 @@ func (gc *GroupCreate) sqlSave(ctx context.Context) (*Group, error) {
 	if err != nil {
 		return nil, err
 	}
-	builder := sql.Insert(group.Table).Default(gc.driver.Dialect())
+	builder := sql.Dialect(gc.driver.Dialect()).
+		Insert(group.Table).
+		Default()
 	if value := gc.name; value != nil {
 		builder.Set(group.FieldName, *value)
 		gr.Name = *value

--- a/examples/m2m2types/ent/user_create.go
+++ b/examples/m2m2types/ent/user_create.go
@@ -83,7 +83,9 @@ func (uc *UserCreate) sqlSave(ctx context.Context) (*User, error) {
 	if err != nil {
 		return nil, err
 	}
-	builder := sql.Insert(user.Table).Default(uc.driver.Dialect())
+	builder := sql.Dialect(uc.driver.Dialect()).
+		Insert(user.Table).
+		Default()
 	if value := uc.age; value != nil {
 		builder.Set(user.FieldAge, *value)
 		u.Age = *value

--- a/examples/m2mbidi/ent/user_create.go
+++ b/examples/m2mbidi/ent/user_create.go
@@ -83,7 +83,9 @@ func (uc *UserCreate) sqlSave(ctx context.Context) (*User, error) {
 	if err != nil {
 		return nil, err
 	}
-	builder := sql.Insert(user.Table).Default(uc.driver.Dialect())
+	builder := sql.Dialect(uc.driver.Dialect()).
+		Insert(user.Table).
+		Default()
 	if value := uc.age; value != nil {
 		builder.Set(user.FieldAge, *value)
 		u.Age = *value

--- a/examples/m2mrecur/ent/user_create.go
+++ b/examples/m2mrecur/ent/user_create.go
@@ -104,7 +104,9 @@ func (uc *UserCreate) sqlSave(ctx context.Context) (*User, error) {
 	if err != nil {
 		return nil, err
 	}
-	builder := sql.Insert(user.Table).Default(uc.driver.Dialect())
+	builder := sql.Dialect(uc.driver.Dialect()).
+		Insert(user.Table).
+		Default()
 	if value := uc.age; value != nil {
 		builder.Set(user.FieldAge, *value)
 		u.Age = *value

--- a/examples/o2m2types/ent/pet_create.go
+++ b/examples/o2m2types/ent/pet_create.go
@@ -78,7 +78,9 @@ func (pc *PetCreate) sqlSave(ctx context.Context) (*Pet, error) {
 	if err != nil {
 		return nil, err
 	}
-	builder := sql.Insert(pet.Table).Default(pc.driver.Dialect())
+	builder := sql.Dialect(pc.driver.Dialect()).
+		Insert(pet.Table).
+		Default()
 	if value := pc.name; value != nil {
 		builder.Set(pet.FieldName, *value)
 		pe.Name = *value

--- a/examples/o2m2types/ent/user_create.go
+++ b/examples/o2m2types/ent/user_create.go
@@ -85,7 +85,9 @@ func (uc *UserCreate) sqlSave(ctx context.Context) (*User, error) {
 	if err != nil {
 		return nil, err
 	}
-	builder := sql.Insert(user.Table).Default(uc.driver.Dialect())
+	builder := sql.Dialect(uc.driver.Dialect()).
+		Insert(user.Table).
+		Default()
 	if value := uc.age; value != nil {
 		builder.Set(user.FieldAge, *value)
 		u.Age = *value

--- a/examples/o2mrecur/ent/node_create.go
+++ b/examples/o2mrecur/ent/node_create.go
@@ -100,7 +100,9 @@ func (nc *NodeCreate) sqlSave(ctx context.Context) (*Node, error) {
 	if err != nil {
 		return nil, err
 	}
-	builder := sql.Insert(node.Table).Default(nc.driver.Dialect())
+	builder := sql.Dialect(nc.driver.Dialect()).
+		Insert(node.Table).
+		Default()
 	if value := nc.value; value != nil {
 		builder.Set(node.FieldValue, *value)
 		n.Value = *value

--- a/examples/o2o2types/ent/card_create.go
+++ b/examples/o2o2types/ent/card_create.go
@@ -85,7 +85,9 @@ func (cc *CardCreate) sqlSave(ctx context.Context) (*Card, error) {
 	if err != nil {
 		return nil, err
 	}
-	builder := sql.Insert(card.Table).Default(cc.driver.Dialect())
+	builder := sql.Dialect(cc.driver.Dialect()).
+		Insert(card.Table).
+		Default()
 	if value := cc.expired; value != nil {
 		builder.Set(card.FieldExpired, *value)
 		c.Expired = *value

--- a/examples/o2o2types/ent/user_create.go
+++ b/examples/o2o2types/ent/user_create.go
@@ -90,7 +90,9 @@ func (uc *UserCreate) sqlSave(ctx context.Context) (*User, error) {
 	if err != nil {
 		return nil, err
 	}
-	builder := sql.Insert(user.Table).Default(uc.driver.Dialect())
+	builder := sql.Dialect(uc.driver.Dialect()).
+		Insert(user.Table).
+		Default()
 	if value := uc.age; value != nil {
 		builder.Set(user.FieldAge, *value)
 		u.Age = *value

--- a/examples/o2obidi/ent/user_create.go
+++ b/examples/o2obidi/ent/user_create.go
@@ -89,7 +89,9 @@ func (uc *UserCreate) sqlSave(ctx context.Context) (*User, error) {
 	if err != nil {
 		return nil, err
 	}
-	builder := sql.Insert(user.Table).Default(uc.driver.Dialect())
+	builder := sql.Dialect(uc.driver.Dialect()).
+		Insert(user.Table).
+		Default()
 	if value := uc.age; value != nil {
 		builder.Set(user.FieldAge, *value)
 		u.Age = *value

--- a/examples/o2orecur/ent/node_create.go
+++ b/examples/o2orecur/ent/node_create.go
@@ -105,7 +105,9 @@ func (nc *NodeCreate) sqlSave(ctx context.Context) (*Node, error) {
 	if err != nil {
 		return nil, err
 	}
-	builder := sql.Insert(node.Table).Default(nc.driver.Dialect())
+	builder := sql.Dialect(nc.driver.Dialect()).
+		Insert(node.Table).
+		Default()
 	if value := nc.value; value != nil {
 		builder.Set(node.FieldValue, *value)
 		n.Value = *value

--- a/examples/start/ent/car_create.go
+++ b/examples/start/ent/car_create.go
@@ -89,7 +89,9 @@ func (cc *CarCreate) sqlSave(ctx context.Context) (*Car, error) {
 	if err != nil {
 		return nil, err
 	}
-	builder := sql.Insert(car.Table).Default(cc.driver.Dialect())
+	builder := sql.Dialect(cc.driver.Dialect()).
+		Insert(car.Table).
+		Default()
 	if value := cc.model; value != nil {
 		builder.Set(car.FieldModel, *value)
 		c.Model = *value

--- a/examples/start/ent/group_create.go
+++ b/examples/start/ent/group_create.go
@@ -77,7 +77,9 @@ func (gc *GroupCreate) sqlSave(ctx context.Context) (*Group, error) {
 	if err != nil {
 		return nil, err
 	}
-	builder := sql.Insert(group.Table).Default(gc.driver.Dialect())
+	builder := sql.Dialect(gc.driver.Dialect()).
+		Insert(group.Table).
+		Default()
 	if value := gc.name; value != nil {
 		builder.Set(group.FieldName, *value)
 		gr.Name = *value

--- a/examples/start/ent/user_create.go
+++ b/examples/start/ent/user_create.go
@@ -118,7 +118,9 @@ func (uc *UserCreate) sqlSave(ctx context.Context) (*User, error) {
 	if err != nil {
 		return nil, err
 	}
-	builder := sql.Insert(user.Table).Default(uc.driver.Dialect())
+	builder := sql.Dialect(uc.driver.Dialect()).
+		Insert(user.Table).
+		Default()
 	if value := uc.age; value != nil {
 		builder.Set(user.FieldAge, *value)
 		u.Age = *value

--- a/examples/traversal/ent/group_create.go
+++ b/examples/traversal/ent/group_create.go
@@ -99,7 +99,9 @@ func (gc *GroupCreate) sqlSave(ctx context.Context) (*Group, error) {
 	if err != nil {
 		return nil, err
 	}
-	builder := sql.Insert(group.Table).Default(gc.driver.Dialect())
+	builder := sql.Dialect(gc.driver.Dialect()).
+		Insert(group.Table).
+		Default()
 	if value := gc.name; value != nil {
 		builder.Set(group.FieldName, *value)
 		gr.Name = *value

--- a/examples/traversal/ent/pet_create.go
+++ b/examples/traversal/ent/pet_create.go
@@ -99,7 +99,9 @@ func (pc *PetCreate) sqlSave(ctx context.Context) (*Pet, error) {
 	if err != nil {
 		return nil, err
 	}
-	builder := sql.Insert(pet.Table).Default(pc.driver.Dialect())
+	builder := sql.Dialect(pc.driver.Dialect()).
+		Insert(pet.Table).
+		Default()
 	if value := pc.name; value != nil {
 		builder.Set(pet.FieldName, *value)
 		pe.Name = *value

--- a/examples/traversal/ent/user_create.go
+++ b/examples/traversal/ent/user_create.go
@@ -149,7 +149,9 @@ func (uc *UserCreate) sqlSave(ctx context.Context) (*User, error) {
 	if err != nil {
 		return nil, err
 	}
-	builder := sql.Insert(user.Table).Default(uc.driver.Dialect())
+	builder := sql.Dialect(uc.driver.Dialect()).
+		Insert(user.Table).
+		Default()
 	if value := uc.age; value != nil {
 		builder.Set(user.FieldAge, *value)
 		u.Age = *value

--- a/go.mod
+++ b/go.mod
@@ -25,5 +25,5 @@ require (
 	github.com/stretchr/testify v1.4.0
 	go.opencensus.io v0.22.0
 	golang.org/x/sync v0.0.0-20190423024810-112230192c58
-	golang.org/x/tools v0.0.0-20190514171724-faff00d7e7f6
+	golang.org/x/tools v0.0.0-20191012152004-8de300cfc20a
 )

--- a/go.sum
+++ b/go.sum
@@ -70,6 +70,7 @@ golang.org/x/net v0.0.0-20180826012351-8a410e7b638d/go.mod h1:mL1N/T3taQHkDXs73r
 golang.org/x/net v0.0.0-20190213061140-3a22650c66bd/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20190311183353-d8887717615a/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190501004415-9ce7a6920f09/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
+golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
@@ -88,6 +89,9 @@ golang.org/x/tools v0.0.0-20190226205152-f727befe758c/go.mod h1:9Yl7xja0Znq3iFh3
 golang.org/x/tools v0.0.0-20190311212946-11955173bddd/go.mod h1:LCzVGOaR6xXOjkQ3onu1FJEFr0SW1gC7cKk1uF8kGRs=
 golang.org/x/tools v0.0.0-20190514171724-faff00d7e7f6 h1:MfRv9P1q9msQtpNPKv0olEj2ueVViE36KqlG4Br8bAs=
 golang.org/x/tools v0.0.0-20190514171724-faff00d7e7f6/go.mod h1:RgjU9mgBXZiqYHBnxXauZ1Gv1EHHAz9KjViQ78xBX0Q=
+golang.org/x/tools v0.0.0-20191012152004-8de300cfc20a h1:TwMENskLwU2NnWBzrJGEWHqSiGUkO/B4rfyhwqDxDYQ=
+golang.org/x/tools v0.0.0-20191012152004-8de300cfc20a/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
+golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=
 google.golang.org/appengine v1.4.0 h1:/wp5JvzpHIxhs/dumFmF7BXTf3Z+dd4uXta4kVyO508=
 google.golang.org/appengine v1.4.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=


### PR DESCRIPTION
Summary:
We can't run "imports" on files when the state is not completed. Because, "goimports" will drop undefined package. Therefore, it's suspended to end of the writing.

Fixed #88

Differential Revision: D17899321

