### PR TITLE
entc/load: avoid panic due to index out of range

### DIFF
--- a/entc/load/load.go
+++ b/entc/load/load.go
@@ -100,7 +100,7 @@ func (c *Config) load() (string, error) {
 	if err != nil {
 		return "", err
 	}
-	if len(pkgs) == 0 {
+	if len(pkgs) < 2 {
 		return "", fmt.Errorf("missing package information for: %s", c.Path)
 	}
 	entPkg, pkg := pkgs[0], pkgs[1]


### PR DESCRIPTION
Summary: go/packages now returns partial packages instead of error and this can cause an index of out range.

Reviewed By: alexsn

Differential Revision: D17939156

