### PR TITLE
dialect/sql: reduce the number of joins on neighbors without predicates

### DIFF
--- a/dialect/sql/graph.go
+++ b/dialect/sql/graph.go
@@ -78,13 +78,10 @@ func Neighbors(dialect string, s *Step) (q *Selector) {
 			pk1, pk2 = pk2, pk1
 		}
 		to := builder.Table(s.To.Table)
-		from := builder.Table(s.From.Table)
 		join := builder.Table(s.Edge.Table)
 		match := builder.Select(join.C(pk1)).
 			From(join).
-			Join(from).
-			On(join.C(pk2), from.C(s.From.Column)).
-			Where(EQ(from.C(s.From.Column), s.From.V))
+			Where(EQ(join.C(pk2), s.From.V))
 		q = builder.Select().
 			From(to).
 			Join(match).

--- a/dialect/sql/graph_test.go
+++ b/dialect/sql/graph_test.go
@@ -159,6 +159,41 @@ func TestNeighbors(t *testing.T) {
 			wantQuery: "SELECT * FROM `users` JOIN (SELECT `parent_id` FROM `users` WHERE `id` = ?) AS `t1` ON `users`.`id` = `t1`.`parent_id`",
 			wantArgs:  []interface{}{2},
 		},
+		{
+			name: "M2M/2type",
+			input: func() *Step {
+				step := &Step{}
+				step.From.V = 2
+				step.From.Table = "groups"
+				step.From.Column = "id"
+				step.To.Table = "users"
+				step.To.Column = "id"
+				step.Edge.Rel = M2M
+				step.Edge.Table = "user_groups"
+				step.Edge.Columns = []string{"group_id", "user_id"}
+				return step
+			}(),
+			wantQuery: "SELECT * FROM `users` JOIN (SELECT `user_groups`.`user_id` FROM `user_groups` WHERE `user_groups`.`group_id` = ?) AS `t1` ON `users`.`id` = `t1`.`user_id`",
+			wantArgs:  []interface{}{2},
+		},
+		{
+			name: "M2M/2type/inverse",
+			input: func() *Step {
+				step := &Step{}
+				step.From.V = 2
+				step.From.Table = "users"
+				step.From.Column = "id"
+				step.To.Table = "groups"
+				step.To.Column = "id"
+				step.Edge.Rel = M2M
+				step.Edge.Inverse = true
+				step.Edge.Table = "user_groups"
+				step.Edge.Columns = []string{"group_id", "user_id"}
+				return step
+			}(),
+			wantQuery: "SELECT * FROM `groups` JOIN (SELECT `user_groups`.`group_id` FROM `user_groups` WHERE `user_groups`.`user_id` = ?) AS `t1` ON `groups`.`id` = `t1`.`group_id`",
+			wantArgs:  []interface{}{2},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
Summary: Loading the "form" table is not required where there's no predicate on the join.

Differential Revision: D18421062

