### PR TITLE
entc/gen: use custom id type in join table

### DIFF
--- a/entc/gen/graph.go
+++ b/entc/gen/graph.go
@@ -331,9 +331,14 @@ func (g *Graph) Tables() (all []*schema.Table) {
 				})
 			case M2M:
 				t1, t2 := tables[n.Table()], tables[e.Type.Table()]
-				fk1, fk2 := n.ID, e.Type.ID
-				c1 := &schema.Column{Name: e.Rel.Columns[0], Type: fk1.Type.Type}
-				c2 := &schema.Column{Name: e.Rel.Columns[1], Type: fk2.Type.Type}
+				c1 := &schema.Column{Name: e.Rel.Columns[0], Type: field.TypeInt}
+				if ref := n.ID; ref.UserDefined {
+					c1.Type = ref.Type.Type
+				}
+				c2 := &schema.Column{Name: e.Rel.Columns[1], Type: field.TypeInt}
+				if ref := e.Type.ID; ref.UserDefined {
+					c2.Type = ref.Type.Type
+				}
 				all = append(all, &schema.Table{
 					Name:       e.Rel.Table,
 					Columns:    []*schema.Column{c1, c2},


### PR DESCRIPTION
Summary: Only when it's provided by the use explicitly

Differential Revision: D18506319

