### PR TITLE
entc/gen: add the type name to as an index prefix

### DIFF
--- a/entc/gen/type.go
+++ b/entc/gen/type.go
@@ -375,7 +375,10 @@ func (t *Type) AddIndex(idx *load.Index) error {
 	}
 	// If no storage-key was defined for this index, generate one.
 	if idx.StorageKey == "" {
-		index.Name += strings.Join(index.Columns, "_")
+		// Add the type name as a prefix to the index parts, because
+		// multiple types can share the same index attributes.
+		parts := append([]string{strings.ToLower(t.Name)}, index.Columns...)
+		index.Name = strings.Join(parts, "_")
 	}
 	t.Indexes = append(t.Indexes, index)
 	return nil

--- a/entc/integration/ent/migrate/schema.go
+++ b/entc/integration/ent/migrate/schema.go
@@ -129,19 +129,24 @@ var (
 				Columns: []*schema.Column{FilesColumns[2], FilesColumns[1]},
 			},
 			{
-				Name:    "name_user",
+				Name:    "file_name_user",
 				Unique:  true,
 				Columns: []*schema.Column{FilesColumns[2], FilesColumns[3]},
 			},
 			{
-				Name:    "owner_id_type_id",
+				Name:    "file_owner_id_type_id",
 				Unique:  false,
 				Columns: []*schema.Column{FilesColumns[7], FilesColumns[5]},
 			},
 			{
-				Name:    "name_owner_id_type_id",
+				Name:    "file_name_owner_id_type_id",
 				Unique:  true,
 				Columns: []*schema.Column{FilesColumns[2], FilesColumns[7], FilesColumns[5]},
+			},
+			{
+				Name:    "file_name_owner_id",
+				Unique:  false,
+				Columns: []*schema.Column{FilesColumns[2], FilesColumns[7]},
 			},
 		},
 	}
@@ -253,6 +258,13 @@ var (
 
 				RefColumns: []*schema.Column{UsersColumns[0]},
 				OnDelete:   schema.SetNull,
+			},
+		},
+		Indexes: []*schema.Index{
+			{
+				Name:    "pet_name_owner_id",
+				Unique:  false,
+				Columns: []*schema.Column{PetsColumns[1], PetsColumns[2]},
 			},
 		},
 	}

--- a/entc/integration/ent/schema/file.go
+++ b/entc/integration/ent/schema/file.go
@@ -62,5 +62,7 @@ func (File) Indexes() []ent.Index {
 		index.Fields("name").
 			Edges("owner", "type").
 			Unique(),
+		index.Fields("name").
+			Edges("owner"),
 	}
 }

--- a/entc/integration/ent/schema/pet.go
+++ b/entc/integration/ent/schema/pet.go
@@ -8,6 +8,7 @@ import (
 	"github.com/facebookincubator/ent"
 	"github.com/facebookincubator/ent/schema/edge"
 	"github.com/facebookincubator/ent/schema/field"
+	"github.com/facebookincubator/ent/schema/index"
 )
 
 // Pet holds the schema definition for the Pet entity.
@@ -26,9 +27,17 @@ func (Pet) Fields() []ent.Field {
 func (Pet) Edges() []ent.Edge {
 	return []ent.Edge{
 		edge.From("team", User.Type).
-			Unique().Ref("team"),
+			Ref("team").
+			Unique(),
 		edge.From("owner", User.Type).
-			Unique().
-			Ref("pets"),
+			Ref("pets").
+			Unique(),
+	}
+}
+
+func (Pet) Indexes() []ent.Index {
+	return []ent.Index{
+		index.Fields("name").
+			Edges("owner"),
 	}
 }

--- a/entc/integration/migrate/entv1/migrate/schema.go
+++ b/entc/integration/migrate/entv1/migrate/schema.go
@@ -30,7 +30,7 @@ var (
 		ForeignKeys: []*schema.ForeignKey{},
 		Indexes: []*schema.Index{
 			{
-				Name:    "name_address",
+				Name:    "user_name_address",
 				Unique:  true,
 				Columns: []*schema.Column{UsersColumns[2], UsersColumns[3]},
 			},

--- a/entc/integration/migrate/entv2/migrate/schema.go
+++ b/entc/integration/migrate/entv2/migrate/schema.go
@@ -56,7 +56,7 @@ var (
 		ForeignKeys: []*schema.ForeignKey{},
 		Indexes: []*schema.Index{
 			{
-				Name:    "phone_age",
+				Name:    "user_phone_age",
 				Unique:  true,
 				Columns: []*schema.Column{UsersColumns[3], UsersColumns[1]},
 			},

--- a/examples/edgeindex/ent/city.go
+++ b/examples/edgeindex/ent/city.go
@@ -24,19 +24,19 @@ type City struct {
 
 // FromRows scans the sql response data into City.
 func (c *City) FromRows(rows *sql.Rows) error {
-	var vc struct {
+	var scanc struct {
 		ID   int
 		Name sql.NullString
 	}
 	// the order here should be the same as in the `city.Columns`.
 	if err := rows.Scan(
-		&vc.ID,
-		&vc.Name,
+		&scanc.ID,
+		&scanc.Name,
 	); err != nil {
 		return err
 	}
-	c.ID = vc.ID
-	c.Name = vc.Name.String
+	c.ID = scanc.ID
+	c.Name = scanc.Name.String
 	return nil
 }
 
@@ -80,11 +80,11 @@ type Cities []*City
 // FromRows scans the sql response data into Cities.
 func (c *Cities) FromRows(rows *sql.Rows) error {
 	for rows.Next() {
-		vc := &City{}
-		if err := vc.FromRows(rows); err != nil {
+		scanc := &City{}
+		if err := scanc.FromRows(rows); err != nil {
 			return err
 		}
-		*c = append(*c, vc)
+		*c = append(*c, scanc)
 	}
 	return nil
 }

--- a/examples/edgeindex/ent/migrate/schema.go
+++ b/examples/edgeindex/ent/migrate/schema.go
@@ -46,7 +46,7 @@ var (
 		},
 		Indexes: []*schema.Index{
 			{
-				Name:    "name_city_id",
+				Name:    "street_name_city_id",
 				Unique:  true,
 				Columns: []*schema.Column{StreetsColumns[1], StreetsColumns[2]},
 			},

--- a/examples/edgeindex/ent/street.go
+++ b/examples/edgeindex/ent/street.go
@@ -24,19 +24,19 @@ type Street struct {
 
 // FromRows scans the sql response data into Street.
 func (s *Street) FromRows(rows *sql.Rows) error {
-	var vs struct {
+	var scans struct {
 		ID   int
 		Name sql.NullString
 	}
 	// the order here should be the same as in the `street.Columns`.
 	if err := rows.Scan(
-		&vs.ID,
-		&vs.Name,
+		&scans.ID,
+		&scans.Name,
 	); err != nil {
 		return err
 	}
-	s.ID = vs.ID
-	s.Name = vs.Name.String
+	s.ID = scans.ID
+	s.Name = scans.Name.String
 	return nil
 }
 
@@ -80,11 +80,11 @@ type Streets []*Street
 // FromRows scans the sql response data into Streets.
 func (s *Streets) FromRows(rows *sql.Rows) error {
 	for rows.Next() {
-		vs := &Street{}
-		if err := vs.FromRows(rows); err != nil {
+		scans := &Street{}
+		if err := scans.FromRows(rows); err != nil {
 			return err
 		}
-		*s = append(*s, vs)
+		*s = append(*s, scans)
 	}
 	return nil
 }

--- a/examples/entcpkg/ent/user.go
+++ b/examples/entcpkg/ent/user.go
@@ -22,16 +22,16 @@ type User struct {
 
 // FromRows scans the sql response data into User.
 func (u *User) FromRows(rows *sql.Rows) error {
-	var vu struct {
+	var scanu struct {
 		ID int
 	}
 	// the order here should be the same as in the `user.Columns`.
 	if err := rows.Scan(
-		&vu.ID,
+		&scanu.ID,
 	); err != nil {
 		return err
 	}
-	u.ID = vu.ID
+	u.ID = scanu.ID
 	return nil
 }
 
@@ -68,11 +68,11 @@ type Users []*User
 // FromRows scans the sql response data into Users.
 func (u *Users) FromRows(rows *sql.Rows) error {
 	for rows.Next() {
-		vu := &User{}
-		if err := vu.FromRows(rows); err != nil {
+		scanu := &User{}
+		if err := scanu.FromRows(rows); err != nil {
 			return err
 		}
-		*u = append(*u, vu)
+		*u = append(*u, scanu)
 	}
 	return nil
 }

--- a/examples/m2m2types/ent/group.go
+++ b/examples/m2m2types/ent/group.go
@@ -24,19 +24,19 @@ type Group struct {
 
 // FromRows scans the sql response data into Group.
 func (gr *Group) FromRows(rows *sql.Rows) error {
-	var vgr struct {
+	var scangr struct {
 		ID   int
 		Name sql.NullString
 	}
 	// the order here should be the same as in the `group.Columns`.
 	if err := rows.Scan(
-		&vgr.ID,
-		&vgr.Name,
+		&scangr.ID,
+		&scangr.Name,
 	); err != nil {
 		return err
 	}
-	gr.ID = vgr.ID
-	gr.Name = vgr.Name.String
+	gr.ID = scangr.ID
+	gr.Name = scangr.Name.String
 	return nil
 }
 
@@ -80,11 +80,11 @@ type Groups []*Group
 // FromRows scans the sql response data into Groups.
 func (gr *Groups) FromRows(rows *sql.Rows) error {
 	for rows.Next() {
-		vgr := &Group{}
-		if err := vgr.FromRows(rows); err != nil {
+		scangr := &Group{}
+		if err := scangr.FromRows(rows); err != nil {
 			return err
 		}
-		*gr = append(*gr, vgr)
+		*gr = append(*gr, scangr)
 	}
 	return nil
 }

--- a/examples/m2m2types/ent/user.go
+++ b/examples/m2m2types/ent/user.go
@@ -26,22 +26,22 @@ type User struct {
 
 // FromRows scans the sql response data into User.
 func (u *User) FromRows(rows *sql.Rows) error {
-	var vu struct {
+	var scanu struct {
 		ID   int
 		Age  sql.NullInt64
 		Name sql.NullString
 	}
 	// the order here should be the same as in the `user.Columns`.
 	if err := rows.Scan(
-		&vu.ID,
-		&vu.Age,
-		&vu.Name,
+		&scanu.ID,
+		&scanu.Age,
+		&scanu.Name,
 	); err != nil {
 		return err
 	}
-	u.ID = vu.ID
-	u.Age = int(vu.Age.Int64)
-	u.Name = vu.Name.String
+	u.ID = scanu.ID
+	u.Age = int(scanu.Age.Int64)
+	u.Name = scanu.Name.String
 	return nil
 }
 
@@ -87,11 +87,11 @@ type Users []*User
 // FromRows scans the sql response data into Users.
 func (u *Users) FromRows(rows *sql.Rows) error {
 	for rows.Next() {
-		vu := &User{}
-		if err := vu.FromRows(rows); err != nil {
+		scanu := &User{}
+		if err := scanu.FromRows(rows); err != nil {
 			return err
 		}
-		*u = append(*u, vu)
+		*u = append(*u, scanu)
 	}
 	return nil
 }

--- a/examples/m2mbidi/ent/user.go
+++ b/examples/m2mbidi/ent/user.go
@@ -26,22 +26,22 @@ type User struct {
 
 // FromRows scans the sql response data into User.
 func (u *User) FromRows(rows *sql.Rows) error {
-	var vu struct {
+	var scanu struct {
 		ID   int
 		Age  sql.NullInt64
 		Name sql.NullString
 	}
 	// the order here should be the same as in the `user.Columns`.
 	if err := rows.Scan(
-		&vu.ID,
-		&vu.Age,
-		&vu.Name,
+		&scanu.ID,
+		&scanu.Age,
+		&scanu.Name,
 	); err != nil {
 		return err
 	}
-	u.ID = vu.ID
-	u.Age = int(vu.Age.Int64)
-	u.Name = vu.Name.String
+	u.ID = scanu.ID
+	u.Age = int(scanu.Age.Int64)
+	u.Name = scanu.Name.String
 	return nil
 }
 
@@ -87,11 +87,11 @@ type Users []*User
 // FromRows scans the sql response data into Users.
 func (u *Users) FromRows(rows *sql.Rows) error {
 	for rows.Next() {
-		vu := &User{}
-		if err := vu.FromRows(rows); err != nil {
+		scanu := &User{}
+		if err := scanu.FromRows(rows); err != nil {
 			return err
 		}
-		*u = append(*u, vu)
+		*u = append(*u, scanu)
 	}
 	return nil
 }

--- a/examples/m2mrecur/ent/user.go
+++ b/examples/m2mrecur/ent/user.go
@@ -26,22 +26,22 @@ type User struct {
 
 // FromRows scans the sql response data into User.
 func (u *User) FromRows(rows *sql.Rows) error {
-	var vu struct {
+	var scanu struct {
 		ID   int
 		Age  sql.NullInt64
 		Name sql.NullString
 	}
 	// the order here should be the same as in the `user.Columns`.
 	if err := rows.Scan(
-		&vu.ID,
-		&vu.Age,
-		&vu.Name,
+		&scanu.ID,
+		&scanu.Age,
+		&scanu.Name,
 	); err != nil {
 		return err
 	}
-	u.ID = vu.ID
-	u.Age = int(vu.Age.Int64)
-	u.Name = vu.Name.String
+	u.ID = scanu.ID
+	u.Age = int(scanu.Age.Int64)
+	u.Name = scanu.Name.String
 	return nil
 }
 
@@ -92,11 +92,11 @@ type Users []*User
 // FromRows scans the sql response data into Users.
 func (u *Users) FromRows(rows *sql.Rows) error {
 	for rows.Next() {
-		vu := &User{}
-		if err := vu.FromRows(rows); err != nil {
+		scanu := &User{}
+		if err := scanu.FromRows(rows); err != nil {
 			return err
 		}
-		*u = append(*u, vu)
+		*u = append(*u, scanu)
 	}
 	return nil
 }

--- a/examples/o2m2types/ent/pet.go
+++ b/examples/o2m2types/ent/pet.go
@@ -24,19 +24,19 @@ type Pet struct {
 
 // FromRows scans the sql response data into Pet.
 func (pe *Pet) FromRows(rows *sql.Rows) error {
-	var vpe struct {
+	var scanpe struct {
 		ID   int
 		Name sql.NullString
 	}
 	// the order here should be the same as in the `pet.Columns`.
 	if err := rows.Scan(
-		&vpe.ID,
-		&vpe.Name,
+		&scanpe.ID,
+		&scanpe.Name,
 	); err != nil {
 		return err
 	}
-	pe.ID = vpe.ID
-	pe.Name = vpe.Name.String
+	pe.ID = scanpe.ID
+	pe.Name = scanpe.Name.String
 	return nil
 }
 
@@ -80,11 +80,11 @@ type Pets []*Pet
 // FromRows scans the sql response data into Pets.
 func (pe *Pets) FromRows(rows *sql.Rows) error {
 	for rows.Next() {
-		vpe := &Pet{}
-		if err := vpe.FromRows(rows); err != nil {
+		scanpe := &Pet{}
+		if err := scanpe.FromRows(rows); err != nil {
 			return err
 		}
-		*pe = append(*pe, vpe)
+		*pe = append(*pe, scanpe)
 	}
 	return nil
 }

--- a/examples/o2m2types/ent/user.go
+++ b/examples/o2m2types/ent/user.go
@@ -26,22 +26,22 @@ type User struct {
 
 // FromRows scans the sql response data into User.
 func (u *User) FromRows(rows *sql.Rows) error {
-	var vu struct {
+	var scanu struct {
 		ID   int
 		Age  sql.NullInt64
 		Name sql.NullString
 	}
 	// the order here should be the same as in the `user.Columns`.
 	if err := rows.Scan(
-		&vu.ID,
-		&vu.Age,
-		&vu.Name,
+		&scanu.ID,
+		&scanu.Age,
+		&scanu.Name,
 	); err != nil {
 		return err
 	}
-	u.ID = vu.ID
-	u.Age = int(vu.Age.Int64)
-	u.Name = vu.Name.String
+	u.ID = scanu.ID
+	u.Age = int(scanu.Age.Int64)
+	u.Name = scanu.Name.String
 	return nil
 }
 
@@ -87,11 +87,11 @@ type Users []*User
 // FromRows scans the sql response data into Users.
 func (u *Users) FromRows(rows *sql.Rows) error {
 	for rows.Next() {
-		vu := &User{}
-		if err := vu.FromRows(rows); err != nil {
+		scanu := &User{}
+		if err := scanu.FromRows(rows); err != nil {
 			return err
 		}
-		*u = append(*u, vu)
+		*u = append(*u, scanu)
 	}
 	return nil
 }

--- a/examples/o2mrecur/ent/node.go
+++ b/examples/o2mrecur/ent/node.go
@@ -24,19 +24,19 @@ type Node struct {
 
 // FromRows scans the sql response data into Node.
 func (n *Node) FromRows(rows *sql.Rows) error {
-	var vn struct {
+	var scann struct {
 		ID    int
 		Value sql.NullInt64
 	}
 	// the order here should be the same as in the `node.Columns`.
 	if err := rows.Scan(
-		&vn.ID,
-		&vn.Value,
+		&scann.ID,
+		&scann.Value,
 	); err != nil {
 		return err
 	}
-	n.ID = vn.ID
-	n.Value = int(vn.Value.Int64)
+	n.ID = scann.ID
+	n.Value = int(scann.Value.Int64)
 	return nil
 }
 
@@ -85,11 +85,11 @@ type Nodes []*Node
 // FromRows scans the sql response data into Nodes.
 func (n *Nodes) FromRows(rows *sql.Rows) error {
 	for rows.Next() {
-		vn := &Node{}
-		if err := vn.FromRows(rows); err != nil {
+		scann := &Node{}
+		if err := scann.FromRows(rows); err != nil {
 			return err
 		}
-		*n = append(*n, vn)
+		*n = append(*n, scann)
 	}
 	return nil
 }

--- a/examples/o2o2types/ent/card.go
+++ b/examples/o2o2types/ent/card.go
@@ -27,22 +27,22 @@ type Card struct {
 
 // FromRows scans the sql response data into Card.
 func (c *Card) FromRows(rows *sql.Rows) error {
-	var vc struct {
+	var scanc struct {
 		ID      int
 		Expired sql.NullTime
 		Number  sql.NullString
 	}
 	// the order here should be the same as in the `card.Columns`.
 	if err := rows.Scan(
-		&vc.ID,
-		&vc.Expired,
-		&vc.Number,
+		&scanc.ID,
+		&scanc.Expired,
+		&scanc.Number,
 	); err != nil {
 		return err
 	}
-	c.ID = vc.ID
-	c.Expired = vc.Expired.Time
-	c.Number = vc.Number.String
+	c.ID = scanc.ID
+	c.Expired = scanc.Expired.Time
+	c.Number = scanc.Number.String
 	return nil
 }
 
@@ -88,11 +88,11 @@ type Cards []*Card
 // FromRows scans the sql response data into Cards.
 func (c *Cards) FromRows(rows *sql.Rows) error {
 	for rows.Next() {
-		vc := &Card{}
-		if err := vc.FromRows(rows); err != nil {
+		scanc := &Card{}
+		if err := scanc.FromRows(rows); err != nil {
 			return err
 		}
-		*c = append(*c, vc)
+		*c = append(*c, scanc)
 	}
 	return nil
 }

--- a/examples/o2o2types/ent/user.go
+++ b/examples/o2o2types/ent/user.go
@@ -26,22 +26,22 @@ type User struct {
 
 // FromRows scans the sql response data into User.
 func (u *User) FromRows(rows *sql.Rows) error {
-	var vu struct {
+	var scanu struct {
 		ID   int
 		Age  sql.NullInt64
 		Name sql.NullString
 	}
 	// the order here should be the same as in the `user.Columns`.
 	if err := rows.Scan(
-		&vu.ID,
-		&vu.Age,
-		&vu.Name,
+		&scanu.ID,
+		&scanu.Age,
+		&scanu.Name,
 	); err != nil {
 		return err
 	}
-	u.ID = vu.ID
-	u.Age = int(vu.Age.Int64)
-	u.Name = vu.Name.String
+	u.ID = scanu.ID
+	u.Age = int(scanu.Age.Int64)
+	u.Name = scanu.Name.String
 	return nil
 }
 
@@ -87,11 +87,11 @@ type Users []*User
 // FromRows scans the sql response data into Users.
 func (u *Users) FromRows(rows *sql.Rows) error {
 	for rows.Next() {
-		vu := &User{}
-		if err := vu.FromRows(rows); err != nil {
+		scanu := &User{}
+		if err := scanu.FromRows(rows); err != nil {
 			return err
 		}
-		*u = append(*u, vu)
+		*u = append(*u, scanu)
 	}
 	return nil
 }

--- a/examples/o2obidi/ent/user.go
+++ b/examples/o2obidi/ent/user.go
@@ -26,22 +26,22 @@ type User struct {
 
 // FromRows scans the sql response data into User.
 func (u *User) FromRows(rows *sql.Rows) error {
-	var vu struct {
+	var scanu struct {
 		ID   int
 		Age  sql.NullInt64
 		Name sql.NullString
 	}
 	// the order here should be the same as in the `user.Columns`.
 	if err := rows.Scan(
-		&vu.ID,
-		&vu.Age,
-		&vu.Name,
+		&scanu.ID,
+		&scanu.Age,
+		&scanu.Name,
 	); err != nil {
 		return err
 	}
-	u.ID = vu.ID
-	u.Age = int(vu.Age.Int64)
-	u.Name = vu.Name.String
+	u.ID = scanu.ID
+	u.Age = int(scanu.Age.Int64)
+	u.Name = scanu.Name.String
 	return nil
 }
 
@@ -87,11 +87,11 @@ type Users []*User
 // FromRows scans the sql response data into Users.
 func (u *Users) FromRows(rows *sql.Rows) error {
 	for rows.Next() {
-		vu := &User{}
-		if err := vu.FromRows(rows); err != nil {
+		scanu := &User{}
+		if err := scanu.FromRows(rows); err != nil {
 			return err
 		}
-		*u = append(*u, vu)
+		*u = append(*u, scanu)
 	}
 	return nil
 }

--- a/examples/o2orecur/ent/node.go
+++ b/examples/o2orecur/ent/node.go
@@ -24,19 +24,19 @@ type Node struct {
 
 // FromRows scans the sql response data into Node.
 func (n *Node) FromRows(rows *sql.Rows) error {
-	var vn struct {
+	var scann struct {
 		ID    int
 		Value sql.NullInt64
 	}
 	// the order here should be the same as in the `node.Columns`.
 	if err := rows.Scan(
-		&vn.ID,
-		&vn.Value,
+		&scann.ID,
+		&scann.Value,
 	); err != nil {
 		return err
 	}
-	n.ID = vn.ID
-	n.Value = int(vn.Value.Int64)
+	n.ID = scann.ID
+	n.Value = int(scann.Value.Int64)
 	return nil
 }
 
@@ -85,11 +85,11 @@ type Nodes []*Node
 // FromRows scans the sql response data into Nodes.
 func (n *Nodes) FromRows(rows *sql.Rows) error {
 	for rows.Next() {
-		vn := &Node{}
-		if err := vn.FromRows(rows); err != nil {
+		scann := &Node{}
+		if err := scann.FromRows(rows); err != nil {
 			return err
 		}
-		*n = append(*n, vn)
+		*n = append(*n, scann)
 	}
 	return nil
 }

--- a/examples/start/ent/car.go
+++ b/examples/start/ent/car.go
@@ -27,22 +27,22 @@ type Car struct {
 
 // FromRows scans the sql response data into Car.
 func (c *Car) FromRows(rows *sql.Rows) error {
-	var vc struct {
+	var scanc struct {
 		ID           int
 		Model        sql.NullString
 		RegisteredAt sql.NullTime
 	}
 	// the order here should be the same as in the `car.Columns`.
 	if err := rows.Scan(
-		&vc.ID,
-		&vc.Model,
-		&vc.RegisteredAt,
+		&scanc.ID,
+		&scanc.Model,
+		&scanc.RegisteredAt,
 	); err != nil {
 		return err
 	}
-	c.ID = vc.ID
-	c.Model = vc.Model.String
-	c.RegisteredAt = vc.RegisteredAt.Time
+	c.ID = scanc.ID
+	c.Model = scanc.Model.String
+	c.RegisteredAt = scanc.RegisteredAt.Time
 	return nil
 }
 
@@ -88,11 +88,11 @@ type Cars []*Car
 // FromRows scans the sql response data into Cars.
 func (c *Cars) FromRows(rows *sql.Rows) error {
 	for rows.Next() {
-		vc := &Car{}
-		if err := vc.FromRows(rows); err != nil {
+		scanc := &Car{}
+		if err := scanc.FromRows(rows); err != nil {
 			return err
 		}
-		*c = append(*c, vc)
+		*c = append(*c, scanc)
 	}
 	return nil
 }

--- a/examples/start/ent/group.go
+++ b/examples/start/ent/group.go
@@ -24,19 +24,19 @@ type Group struct {
 
 // FromRows scans the sql response data into Group.
 func (gr *Group) FromRows(rows *sql.Rows) error {
-	var vgr struct {
+	var scangr struct {
 		ID   int
 		Name sql.NullString
 	}
 	// the order here should be the same as in the `group.Columns`.
 	if err := rows.Scan(
-		&vgr.ID,
-		&vgr.Name,
+		&scangr.ID,
+		&scangr.Name,
 	); err != nil {
 		return err
 	}
-	gr.ID = vgr.ID
-	gr.Name = vgr.Name.String
+	gr.ID = scangr.ID
+	gr.Name = scangr.Name.String
 	return nil
 }
 
@@ -80,11 +80,11 @@ type Groups []*Group
 // FromRows scans the sql response data into Groups.
 func (gr *Groups) FromRows(rows *sql.Rows) error {
 	for rows.Next() {
-		vgr := &Group{}
-		if err := vgr.FromRows(rows); err != nil {
+		scangr := &Group{}
+		if err := scangr.FromRows(rows); err != nil {
 			return err
 		}
-		*gr = append(*gr, vgr)
+		*gr = append(*gr, scangr)
 	}
 	return nil
 }

--- a/examples/start/ent/user.go
+++ b/examples/start/ent/user.go
@@ -26,22 +26,22 @@ type User struct {
 
 // FromRows scans the sql response data into User.
 func (u *User) FromRows(rows *sql.Rows) error {
-	var vu struct {
+	var scanu struct {
 		ID   int
 		Age  sql.NullInt64
 		Name sql.NullString
 	}
 	// the order here should be the same as in the `user.Columns`.
 	if err := rows.Scan(
-		&vu.ID,
-		&vu.Age,
-		&vu.Name,
+		&scanu.ID,
+		&scanu.Age,
+		&scanu.Name,
 	); err != nil {
 		return err
 	}
-	u.ID = vu.ID
-	u.Age = int(vu.Age.Int64)
-	u.Name = vu.Name.String
+	u.ID = scanu.ID
+	u.Age = int(scanu.Age.Int64)
+	u.Name = scanu.Name.String
 	return nil
 }
 
@@ -92,11 +92,11 @@ type Users []*User
 // FromRows scans the sql response data into Users.
 func (u *Users) FromRows(rows *sql.Rows) error {
 	for rows.Next() {
-		vu := &User{}
-		if err := vu.FromRows(rows); err != nil {
+		scanu := &User{}
+		if err := scanu.FromRows(rows); err != nil {
 			return err
 		}
-		*u = append(*u, vu)
+		*u = append(*u, scanu)
 	}
 	return nil
 }

--- a/examples/traversal/ent/group.go
+++ b/examples/traversal/ent/group.go
@@ -24,19 +24,19 @@ type Group struct {
 
 // FromRows scans the sql response data into Group.
 func (gr *Group) FromRows(rows *sql.Rows) error {
-	var vgr struct {
+	var scangr struct {
 		ID   int
 		Name sql.NullString
 	}
 	// the order here should be the same as in the `group.Columns`.
 	if err := rows.Scan(
-		&vgr.ID,
-		&vgr.Name,
+		&scangr.ID,
+		&scangr.Name,
 	); err != nil {
 		return err
 	}
-	gr.ID = vgr.ID
-	gr.Name = vgr.Name.String
+	gr.ID = scangr.ID
+	gr.Name = scangr.Name.String
 	return nil
 }
 
@@ -85,11 +85,11 @@ type Groups []*Group
 // FromRows scans the sql response data into Groups.
 func (gr *Groups) FromRows(rows *sql.Rows) error {
 	for rows.Next() {
-		vgr := &Group{}
-		if err := vgr.FromRows(rows); err != nil {
+		scangr := &Group{}
+		if err := scangr.FromRows(rows); err != nil {
 			return err
 		}
-		*gr = append(*gr, vgr)
+		*gr = append(*gr, scangr)
 	}
 	return nil
 }

--- a/examples/traversal/ent/pet.go
+++ b/examples/traversal/ent/pet.go
@@ -24,19 +24,19 @@ type Pet struct {
 
 // FromRows scans the sql response data into Pet.
 func (pe *Pet) FromRows(rows *sql.Rows) error {
-	var vpe struct {
+	var scanpe struct {
 		ID   int
 		Name sql.NullString
 	}
 	// the order here should be the same as in the `pet.Columns`.
 	if err := rows.Scan(
-		&vpe.ID,
-		&vpe.Name,
+		&scanpe.ID,
+		&scanpe.Name,
 	); err != nil {
 		return err
 	}
-	pe.ID = vpe.ID
-	pe.Name = vpe.Name.String
+	pe.ID = scanpe.ID
+	pe.Name = scanpe.Name.String
 	return nil
 }
 
@@ -85,11 +85,11 @@ type Pets []*Pet
 // FromRows scans the sql response data into Pets.
 func (pe *Pets) FromRows(rows *sql.Rows) error {
 	for rows.Next() {
-		vpe := &Pet{}
-		if err := vpe.FromRows(rows); err != nil {
+		scanpe := &Pet{}
+		if err := scanpe.FromRows(rows); err != nil {
 			return err
 		}
-		*pe = append(*pe, vpe)
+		*pe = append(*pe, scanpe)
 	}
 	return nil
 }

--- a/examples/traversal/ent/user.go
+++ b/examples/traversal/ent/user.go
@@ -26,22 +26,22 @@ type User struct {
 
 // FromRows scans the sql response data into User.
 func (u *User) FromRows(rows *sql.Rows) error {
-	var vu struct {
+	var scanu struct {
 		ID   int
 		Age  sql.NullInt64
 		Name sql.NullString
 	}
 	// the order here should be the same as in the `user.Columns`.
 	if err := rows.Scan(
-		&vu.ID,
-		&vu.Age,
-		&vu.Name,
+		&scanu.ID,
+		&scanu.Age,
+		&scanu.Name,
 	); err != nil {
 		return err
 	}
-	u.ID = vu.ID
-	u.Age = int(vu.Age.Int64)
-	u.Name = vu.Name.String
+	u.ID = scanu.ID
+	u.Age = int(scanu.Age.Int64)
+	u.Name = scanu.Name.String
 	return nil
 }
 
@@ -102,11 +102,11 @@ type Users []*User
 // FromRows scans the sql response data into Users.
 func (u *Users) FromRows(rows *sql.Rows) error {
 	for rows.Next() {
-		vu := &User{}
-		if err := vu.FromRows(rows); err != nil {
+		scanu := &User{}
+		if err := scanu.FromRows(rows); err != nil {
 			return err
 		}
-		*u = append(*u, vu)
+		*u = append(*u, scanu)
 	}
 	return nil
 }


### PR DESCRIPTION
Summary:
Note that this is a non backwards compatible change.

I'll add another change (before this) for setting the storage-key of the index, and only after that we can land this.

Differential Revision: D18570445

