### PR TITLE
Resolve panic where nothing would be migrated with SQLite3 driver

### DIFF
--- a/dialect/sql/schema/migrate.go
+++ b/dialect/sql/schema/migrate.go
@@ -237,6 +237,9 @@ type changes struct {
 // It fails if one of the changes is invalid.
 func (m *Migrate) changeSet(curr, new *Table) (*changes, error) {
 	change := &changes{}
+	if curr == nil {
+		return change, nil
+	}
 	// pks.
 	if len(curr.PrimaryKey) != len(new.PrimaryKey) {
 		return nil, fmt.Errorf("cannot change primary key for table: %q", curr.Name)


### PR DESCRIPTION
This was caused by the current state being represented as nil; this was
resolved by returning an empty change set when the current value is nil.

Hoping to turn this into a series of commits where I contribute small additions towards the sqlite3 work. LMK if I'm heading in the right direction; specifically, I don't know where the best place for tests are.