### PR TITLE
add predicates for composite where query

### DIFF
--- a/dialect/sql/builder.go
+++ b/dialect/sql/builder.go
@@ -1069,9 +1069,7 @@ func CompositeLT(columns []string, args ...interface{}) *Predicate {
 	return (&Predicate{}).CompositeLT(columns, args...)
 }
 
-// GT returns a composite ">" predicate.
-func (p *Predicate) CompositeGT(columns []string, args ...interface{}) *Predicate {
-	const operator = " > "
+func (p *Predicate) compositeP(operator string, columns []string, args ...interface{}) *Predicate {
 	return p.append(func(b *Builder) {
 		b.Nested(func(nb *Builder) {
 			nb.IdentComma(columns...)
@@ -1083,18 +1081,16 @@ func (p *Predicate) CompositeGT(columns []string, args ...interface{}) *Predicat
 	})
 }
 
+// GT returns a composite ">" predicate.
+func (p *Predicate) CompositeGT(columns []string, args ...interface{}) *Predicate {
+	const operator = " > "
+	return p.compositeP(operator, columns, args...)
+}
+
 // LT appends a composite "<" predicate.
 func (p *Predicate) CompositeLT(columns []string, args ...interface{}) *Predicate {
 	const operator = " < "
-	return p.append(func(b *Builder) {
-		b.Nested(func(nb *Builder) {
-			nb.IdentComma(columns...)
-		})
-		b.WriteString(operator)
-		b.WriteString("(")
-		b.Args(args...)
-		b.WriteString(")")
-	})
+	return p.compositeP(operator, columns, args...)
 }
 
 // Query returns query representation of a predicate.

--- a/dialect/sql/builder.go
+++ b/dialect/sql/builder.go
@@ -1061,6 +1061,46 @@ func (p *Predicate) ContainsFold(col, sub string) *Predicate {
 	})
 }
 
+func Columns(columns ...string) []string {
+	return columns
+}
+
+func CompositeGT(columns []string, args ...interface{}) *Predicate {
+	return (&Predicate{}).CompositeGT(columns, args...)
+}
+
+func CompositeLT(columns []string, args ...interface{}) *Predicate {
+	return (&Predicate{}).CompositeLT(columns, args...)
+}
+
+// GT returns a composite ">" predicate.
+func (p *Predicate) CompositeGT(columns []string, args ...interface{}) *Predicate {
+	const operator = " > "
+	return p.append(func(b *Builder) {
+		b.Nested(func(nb *Builder) {
+			nb.IdentComma(columns...)
+		})
+		b.WriteString(operator)
+		b.WriteString("(")
+		b.Args(args...)
+		b.WriteString(")")
+	})
+}
+
+// LT appends a composite "<" predicate.
+func (p *Predicate) CompositeLT(columns []string, args ...interface{}) *Predicate {
+	const operator = " < "
+	return p.append(func(b *Builder) {
+		b.Nested(func(nb *Builder) {
+			nb.IdentComma(columns...)
+		})
+		b.WriteString(operator)
+		b.WriteString("(")
+		b.Args(args...)
+		b.WriteString(")")
+	})
+}
+
 // Query returns query representation of a predicate.
 func (p *Predicate) Query() (string, []interface{}) {
 	for _, f := range p.fns {

--- a/dialect/sql/builder.go
+++ b/dialect/sql/builder.go
@@ -1061,10 +1061,6 @@ func (p *Predicate) ContainsFold(col, sub string) *Predicate {
 	})
 }
 
-func Columns(columns ...string) []string {
-	return columns
-}
-
 func CompositeGT(columns []string, args ...interface{}) *Predicate {
 	return (&Predicate{}).CompositeGT(columns, args...)
 }

--- a/dialect/sql/builder_test.go
+++ b/dialect/sql/builder_test.go
@@ -1064,35 +1064,47 @@ func TestBuilder(t *testing.T) {
 			wantArgs:  []interface{}{"baz", 1},
 		},
 		{
-			input: Dialect(dialect.Postgres).
-				Select().
-				From(Table("users")).
-				Where(CompositeGT(Columns("id", "name"), 1, "Ariel")),
-			wantQuery: `SELECT * FROM "users" WHERE ("id", "name") > ($1, $2)`,
+			input: func() Querier {
+				t1 := Table("users")
+				return Dialect(dialect.Postgres).
+					Select().
+					From(t1).
+					Where(CompositeGT(t1.Columns("id", "name"), 1, "Ariel"))
+			}(),
+			wantQuery: `SELECT * FROM "users" WHERE ("users"."id", "users"."name") > ($1, $2)`,
 			wantArgs:  []interface{}{1, "Ariel"},
 		},
 		{
-			input: Dialect(dialect.Postgres).
-				Select().
-				From(Table("users")).
-				Where(And(EQ("name", "Ariel"), CompositeGT(Columns("id", "name"), 1, "Ariel"))),
-			wantQuery: `SELECT * FROM "users" WHERE ("name" = $1) AND (("id", "name") > ($2, $3))`,
+			input: func() Querier {
+				t1 := Table("users")
+				return Dialect(dialect.Postgres).
+					Select().
+					From(t1).
+					Where(And(EQ("name", "Ariel"), CompositeGT(t1.Columns("id", "name"), 1, "Ariel")))
+			}(),
+			wantQuery: `SELECT * FROM "users" WHERE ("name" = $1) AND (("users"."id", "users"."name") > ($2, $3))`,
 			wantArgs:  []interface{}{"Ariel", 1, "Ariel"},
 		},
 		{
-			input: Dialect(dialect.Postgres).
-				Select().
-				From(Table("users")).
-				Where(And(EQ("name", "Ariel"), Or(EQ("surname", "Doe"), CompositeGT(Columns("id", "name"), 1, "Ariel")))),
-			wantQuery: `SELECT * FROM "users" WHERE ("name" = $1) AND ((("surname" = $2) OR (("id", "name") > ($3, $4))))`,
+			input: func() Querier {
+				t1 := Table("users")
+				return Dialect(dialect.Postgres).
+					Select().
+					From(t1).
+					Where(And(EQ("name", "Ariel"), Or(EQ("surname", "Doe"), CompositeGT(t1.Columns("id", "name"), 1, "Ariel"))))
+			}(),
+			wantQuery: `SELECT * FROM "users" WHERE ("name" = $1) AND ((("surname" = $2) OR (("users"."id", "users"."name") > ($3, $4))))`,
 			wantArgs:  []interface{}{"Ariel", "Doe", 1, "Ariel"},
 		},
 		{
-			input: Dialect(dialect.Postgres).
-				Select().
-				From(Table("users")).
-				Where(And(EQ("name", "Ariel"), CompositeLT(Columns("id", "name"), 1, "Ariel"))),
-			wantQuery: `SELECT * FROM "users" WHERE ("name" = $1) AND (("id", "name") < ($2, $3))`,
+			input: func() Querier {
+				t1 := Table("users")
+				return Dialect(dialect.Postgres).
+					Select().
+					From(Table("users")).
+					Where(And(EQ("name", "Ariel"), CompositeLT(t1.Columns("id", "name"), 1, "Ariel")))
+			}(),
+			wantQuery: `SELECT * FROM "users" WHERE ("name" = $1) AND (("users"."id", "users"."name") < ($2, $3))`,
 			wantArgs:  []interface{}{"Ariel", 1, "Ariel"},
 		},
 		{

--- a/dialect/sql/builder_test.go
+++ b/dialect/sql/builder_test.go
@@ -1064,6 +1064,38 @@ func TestBuilder(t *testing.T) {
 			wantArgs:  []interface{}{"baz", 1},
 		},
 		{
+			input: Dialect(dialect.Postgres).
+				Select().
+				From(Table("users")).
+				Where(CompositeGT(Columns("id", "name"), 1, "Ariel")),
+			wantQuery: `SELECT * FROM "users" WHERE ("id", "name") > ($1, $2)`,
+			wantArgs:  []interface{}{1, "Ariel"},
+		},
+		{
+			input: Dialect(dialect.Postgres).
+				Select().
+				From(Table("users")).
+				Where(And(EQ("name", "Ariel"), CompositeGT(Columns("id", "name"), 1, "Ariel"))),
+			wantQuery: `SELECT * FROM "users" WHERE ("name" = $1) AND (("id", "name") > ($2, $3))`,
+			wantArgs:  []interface{}{"Ariel", 1, "Ariel"},
+		},
+		{
+			input: Dialect(dialect.Postgres).
+				Select().
+				From(Table("users")).
+				Where(And(EQ("name", "Ariel"), Or(EQ("surname", "Doe"), CompositeGT(Columns("id", "name"), 1, "Ariel")))),
+			wantQuery: `SELECT * FROM "users" WHERE ("name" = $1) AND ((("surname" = $2) OR (("id", "name") > ($3, $4))))`,
+			wantArgs:  []interface{}{"Ariel", "Doe", 1, "Ariel"},
+		},
+		{
+			input: Dialect(dialect.Postgres).
+				Select().
+				From(Table("users")).
+				Where(And(EQ("name", "Ariel"), CompositeLT(Columns("id", "name"), 1, "Ariel"))),
+			wantQuery: `SELECT * FROM "users" WHERE ("name" = $1) AND (("id", "name") < ($2, $3))`,
+			wantArgs:  []interface{}{"Ariel", 1, "Ariel"},
+		},
+		{
 			input:     CreateIndex("name_index").Table("users").Column("name"),
 			wantQuery: "CREATE INDEX `name_index` ON `users`(`name`)",
 		},


### PR DESCRIPTION
Implements the predicates for composite where queries. It is the first step towards key-set pagination support as discussed in #215