### PR TITLE
entc/gen: change name format for edge fks

### DIFF
--- a/dialect/sql/builder.go
+++ b/dialect/sql/builder.go
@@ -238,6 +238,12 @@ func (t *TableAlter) ModifyColumn(c *ColumnBuilder) *TableAlter {
 	return t
 }
 
+// RenameColumn appends the `RENAME COLUMN` clause to the given `ALTER TABLE` statement.
+func (t *TableAlter) RenameColumn(old, new string) *TableAlter {
+	t.Queries = append(t.Queries, Raw(fmt.Sprintf("RENAME COLUMN %s TO %s", t.Quote(old), t.Quote(new))))
+	return t
+}
+
 // ModifyColumns calls ModifyColumn with each of the given builders.
 func (t *TableAlter) ModifyColumns(cs ...*ColumnBuilder) *TableAlter {
 	for _, c := range cs {

--- a/dialect/sql/scan_test.go
+++ b/dialect/sql/scan_test.go
@@ -153,6 +153,26 @@ func TestScanInt64(t *testing.T) {
 	require.EqualValues(t, 10, n)
 }
 
+func TestScanOne(t *testing.T) {
+	mock := sqlmock.NewRows([]string{"name"}).
+		AddRow("10").
+		AddRow("20")
+	err := ScanOne(toRows(mock), new(string))
+	require.Error(t, err, "multiple lines")
+
+	mock = sqlmock.NewRows([]string{"name"}).
+		AddRow("10")
+	err = ScanOne(toRows(mock), "")
+	require.Error(t, err, "not a pointer")
+
+	mock = sqlmock.NewRows([]string{"name"}).
+		AddRow("10")
+	var s string
+	err = ScanOne(toRows(mock), &s)
+	require.NoError(t, err)
+	require.Equal(t, "10", s)
+}
+
 func TestInterface(t *testing.T) {
 	mock := sqlmock.NewRows([]string{"age"}).
 		AddRow("10").

--- a/dialect/sql/schema/migrate.go
+++ b/dialect/sql/schema/migrate.go
@@ -406,6 +406,9 @@ func (m *Migrate) setupTable(t *Table) {
 	}
 	for _, fk := range t.ForeignKeys {
 		fk.Symbol = m.symbol(fk.Symbol)
+		for _, c := range fk.Columns {
+			c.foreign = fk
+		}
 	}
 }
 

--- a/dialect/sql/schema/mysql_test.go
+++ b/dialect/sql/schema/mysql_test.go
@@ -756,8 +756,8 @@ func TestMySQL_Create(t *testing.T) {
 				mock.ExpectQuery(escape("SELECT COUNT(*) FROM INFORMATION_SCHEMA.TABLE_CONSTRAINTS WHERE `TABLE_SCHEMA` = (SELECT DATABASE()) AND `CONSTRAINT_TYPE` = ? AND `CONSTRAINT_NAME` = ?")).
 					WithArgs("FOREIGN KEY", "parent_id").
 					WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(1))
-				mock.ExpectQuery(escape("SELECT `COLUMN_NAME` FROM INFORMATION_SCHEMA.KEY_COLUMN_USAGE JOIN INFORMATION_SCHEMA.TABLE_CONSTRAINTS ON `KEY_COLUMN_USAGE`.`CONSTRAINT_NAME` = `TABLE_CONSTRAINTS`.`CONSTRAINT_NAME` WHERE (`TABLE_CONSTRAINTS`.`CONSTRAINT_NAME` = ?) AND (`TABLE_CONSTRAINTS`.`CONSTRAINT_TYPE` = ?) AND (`KEY_COLUMN_USAGE`.`TABLE_SCHEMA` = (SELECT DATABASE()))")).
-					WithArgs("parent_id", "FOREIGN KEY").
+				mock.ExpectQuery(escape("SELECT `column_name` FROM INFORMATION_SCHEMA.KEY_COLUMN_USAGE AS t1 JOIN INFORMATION_SCHEMA.TABLE_CONSTRAINTS AS t2 ON `t1`.`constraint_name` = `t2`.`constraint_name` WHERE (`t2`.`constraint_type` = 'FOREIGN KEY') AND (`t2`.`table_schema` = (SELECT DATABASE())) AND (`t1`.`table_schema` = (SELECT DATABASE())) AND (`t2`.`constraint_name` = ?)")).
+					WithArgs("parent_id").
 					WillReturnRows(sqlmock.NewRows([]string{"COLUMN_NAME"}).
 						AddRow("parent_id"))
 				// drop the unique index.

--- a/dialect/sql/schema/mysql_test.go
+++ b/dialect/sql/schema/mysql_test.go
@@ -753,6 +753,13 @@ func TestMySQL_Create(t *testing.T) {
 						AddRow("PRIMARY", "id", "0", "1").
 						AddRow("old_index", "old", "0", "1").
 						AddRow("parent_id", "parent_id", "0", "1"))
+				mock.ExpectQuery(escape("SELECT COUNT(*) FROM INFORMATION_SCHEMA.TABLE_CONSTRAINTS WHERE `TABLE_SCHEMA` = (SELECT DATABASE()) AND `CONSTRAINT_TYPE` = ? AND `CONSTRAINT_NAME` = ?")).
+					WithArgs("FOREIGN KEY", "parent_id").
+					WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(1))
+				mock.ExpectQuery(escape("SELECT `COLUMN_NAME` FROM INFORMATION_SCHEMA.KEY_COLUMN_USAGE JOIN INFORMATION_SCHEMA.TABLE_CONSTRAINTS ON `KEY_COLUMN_USAGE`.`CONSTRAINT_NAME` = `TABLE_CONSTRAINTS`.`CONSTRAINT_NAME` WHERE (`TABLE_CONSTRAINTS`.`CONSTRAINT_NAME` = ?) AND (`TABLE_CONSTRAINTS`.`CONSTRAINT_TYPE` = ?) AND (`KEY_COLUMN_USAGE`.`TABLE_SCHEMA` = (SELECT DATABASE()))")).
+					WithArgs("parent_id", "FOREIGN KEY").
+					WillReturnRows(sqlmock.NewRows([]string{"COLUMN_NAME"}).
+						AddRow("parent_id"))
 				// drop the unique index.
 				mock.ExpectExec(escape("DROP INDEX `old_index` ON `users`")).
 					WillReturnResult(sqlmock.NewResult(0, 1))
@@ -895,9 +902,13 @@ func TestMySQL_Create(t *testing.T) {
 					WithArgs("users").
 					WillReturnRows(sqlmock.NewRows([]string{"index_name", "column_name", "non_unique", "seq_in_index"}).
 						AddRow("PRIMARY", "id", "0", "1"))
+				mock.ExpectQuery(escape("SELECT COUNT(*) FROM INFORMATION_SCHEMA.TABLE_CONSTRAINTS WHERE `TABLE_SCHEMA` = (SELECT DATABASE()) AND `CONSTRAINT_TYPE` = ? AND `CONSTRAINT_NAME` = ?")).
+					WithArgs("FOREIGN KEY", "user_spouse_____________________390ed76f91d3c57cd3516e7690f621dc").
+					WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(0))
 				mock.ExpectExec(escape("ALTER TABLE `users` ADD COLUMN `spouse_id` bigint")).
 					WillReturnResult(sqlmock.NewResult(0, 1))
 				mock.ExpectQuery(escape("SELECT COUNT(*) FROM INFORMATION_SCHEMA.TABLE_CONSTRAINTS WHERE `TABLE_SCHEMA` = (SELECT DATABASE()) AND `CONSTRAINT_TYPE` = ? AND `CONSTRAINT_NAME` = ?")).
+					WithArgs("FOREIGN KEY", "user_spouse_____________________390ed76f91d3c57cd3516e7690f621dc").
 					WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(0))
 				mock.ExpectExec("ALTER TABLE `users` ADD CONSTRAINT `.{64}` FOREIGN KEY\\(`spouse_id`\\) REFERENCES `users`\\(`id`\\) ON DELETE CASCADE").
 					WillReturnResult(sqlmock.NewResult(0, 1))

--- a/dialect/sql/schema/postgres.go
+++ b/dialect/sql/schema/postgres.go
@@ -118,10 +118,9 @@ func (d *Postgres) table(ctx context.Context, tx dialect.Tx, name string) (*Tabl
 			}
 			c.Key = UniqueKey
 			c.Unique = true
-			c.indexes.append(idx)
 			fallthrough
 		default:
-			t.AddIndex(idx.Name, idx.Unique, idx.columns)
+			t.addIndex(idx)
 		}
 	}
 	return t, nil
@@ -172,12 +171,12 @@ func (d *Postgres) indexes(ctx context.Context, tx dialect.Tx, table string) (In
 		}
 		// If the index is prefixed with the table, it's probably was
 		// added by `addIndex` (and not entc) and it should be trimmed.
-		name = strings.TrimPrefix(name, table+"_")
-		idx, ok := names[name]
+		short := strings.TrimPrefix(name, table+"_")
+		idx, ok := names[short]
 		if !ok {
-			idx = &Index{Name: name, Unique: unique, primary: primary}
+			idx = &Index{Name: short, Unique: unique, primary: primary, realname: name}
 			idxs = append(idxs, idx)
-			names[name] = idx
+			names[short] = idx
 		}
 		idx.columns = append(idx.columns, column)
 	}
@@ -350,4 +349,54 @@ func (d *Postgres) dropIndex(ctx context.Context, tx dialect.Tx, idx *Index, tab
 		query, args = build.AlterTable(table).DropConstraint(name).Query()
 	}
 	return tx.Exec(ctx, query, args, nil)
+}
+
+// isImplicitIndex reports if the index was created implicitly for the unique column.
+func (d *Postgres) isImplicitIndex(idx *Index, col *Column) bool {
+	return strings.TrimSuffix(idx.Name, "_key") == col.Name && col.Unique
+}
+
+// renameColumn returns the statement for renaming a column.
+func (d *Postgres) renameColumn(t *Table, old, new *Column) sql.Querier {
+	return sql.Dialect(dialect.Postgres).
+		AlterTable(t.Name).
+		RenameColumn(old.Name, new.Name)
+}
+
+// renameIndex returns the statement for renaming an index.
+func (d *Postgres) renameIndex(t *Table, old, new *Index) sql.Querier {
+	if sfx := "_key"; strings.HasSuffix(old.Name, sfx) && !strings.HasSuffix(new.Name, sfx) {
+		new.Name += sfx
+	}
+	if pfx := t.Name + "_"; strings.HasPrefix(old.realname, pfx) && !strings.HasPrefix(new.Name, pfx) {
+		new.Name = pfx + new.Name
+	}
+	return sql.Dialect(dialect.Postgres).AlterIndex(old.realname).Rename(new.Name)
+}
+
+// fkColumn returns the column name of a foreign-key.
+func (d *Postgres) fkColumn(ctx context.Context, tx dialect.Tx, fk *ForeignKey) (string, error) {
+	t1 := sql.Table("INFORMATION_SCHEMA.KEY_COLUMN_USAGE AS t1").Unquote().As("t1")
+	t2 := sql.Table("INFORMATION_SCHEMA.TABLE_CONSTRAINTS AS t2").Unquote().As("t2")
+	query, args := sql.Dialect(dialect.Postgres).
+		Select("column_name").
+		From(t1).
+		Join(t2).
+		On(t1.C("constraint_name"), t2.C("constraint_name")).
+		Where(sql.And(
+			sql.EQ(t2.C("constraint_type"), sql.Raw("'FOREIGN KEY'")),
+			sql.EQ(t1.C("table_schema"), sql.Raw("(CURRENT_SCHEMA())")),
+			sql.EQ(t2.C("constraint_name"), fk.Symbol),
+		)).
+		Query()
+	rows := &sql.Rows{}
+	if err := tx.Query(ctx, query, args, rows); err != nil {
+		return "", fmt.Errorf("reading foreign-key %q column: %v", fk.Symbol, err)
+	}
+	defer rows.Close()
+	column, err := sql.ScanString(rows)
+	if err != nil {
+		return "", fmt.Errorf("scanning foreign-key %q column: %v", fk.Symbol, err)
+	}
+	return column, nil
 }

--- a/dialect/sql/schema/postgres_test.go
+++ b/dialect/sql/schema/postgres_test.go
@@ -564,6 +564,11 @@ func TestPostgres_Create(t *testing.T) {
 				mock.ExpectQuery(escape(fmt.Sprintf(indexesQuery, "users"))).
 					WillReturnRows(sqlmock.NewRows([]string{"index_name", "column_name", "primary", "unique", "seq_in_index"}).
 						AddRow("users_pkey", "id", "t", "t", 0))
+
+				mock.ExpectQuery(escape(`SELECT COUNT(*) FROM INFORMATION_SCHEMA.TABLE_CONSTRAINTS WHERE "table_schema" = CURRENT_SCHEMA() AND "constraint_type" = $1 AND "constraint_name" = $2`)).
+					WithArgs("FOREIGN KEY", "user_spouse____________________390ed76f91d3c57cd3516e7690f621dc").
+					WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(0))
+
 				mock.ExpectExec(escape(`ALTER TABLE "users" ADD COLUMN "spouse_id" bigint NULL`)).
 					WillReturnResult(sqlmock.NewResult(0, 1))
 				mock.ExpectQuery(escape(`SELECT COUNT(*) FROM INFORMATION_SCHEMA.TABLE_CONSTRAINTS WHERE "table_schema" = CURRENT_SCHEMA() AND "constraint_type" = $1 AND "constraint_name" = $2`)).

--- a/dialect/sql/schema/schema.go
+++ b/dialect/sql/schema/schema.go
@@ -142,8 +142,9 @@ type Column struct {
 	Increment bool        // auto increment attribute.
 	Nullable  bool        // null or not null attribute.
 	Default   interface{} // default value.
-	indexes   Indexes     // linked indexes.
 	Enums     []string    // enum values.
+	indexes   Indexes     // linked indexes.
+	foreign   *ForeignKey // linked foreign-key.
 }
 
 // UniqueKey returns boolean indicates if this column is a unique key.

--- a/dialect/sql/schema/schema.go
+++ b/dialect/sql/schema/schema.go
@@ -65,16 +65,20 @@ func (t *Table) AddColumn(c *Column) *Table {
 
 // AddIndex creates and adds a new index to the table from the given options.
 func (t *Table) AddIndex(name string, unique bool, columns []string) *Table {
-	idx := &Index{
+	return t.addIndex(&Index{
 		Name:    name,
 		Unique:  unique,
 		columns: columns,
 		Columns: make([]*Column, 0, len(columns)),
-	}
-	for _, name := range columns {
+	})
+}
+
+// AddIndex creates and adds a new index to the table from the given options.
+func (t *Table) addIndex(idx *Index) *Table {
+	for _, name := range idx.columns {
 		c, ok := t.columns[name]
 		if ok {
-			c.indexes = append(c.indexes, idx)
+			c.indexes.append(idx)
 			idx.Columns = append(idx.Columns, c)
 		}
 	}
@@ -107,11 +111,13 @@ func (t *Table) index(name string) (*Index, bool) {
 		}
 	}
 	// If it is an "implicit index" (unique constraint on
-	// table creation) and it didn't load on table scanning.
+	// table creation) and it wasn't loaded in table scanning.
 	c, ok := t.column(name)
 	if !ok {
-		// Postgres naming convention for unique constraint.
-		c, ok = t.column(strings.TrimSuffix(name, "_key"))
+		// Postgres naming convention for unique constraint (<table>_<column>_key).
+		name = strings.TrimPrefix(name, t.Name+"_")
+		name = strings.TrimSuffix(name, "_key")
+		c, ok = t.column(name)
 	}
 	if ok && c.Unique {
 		return &Index{Name: name, Unique: c.Unique, Columns: []*Column{c}, columns: []string{c.Name}}, true
@@ -144,7 +150,6 @@ type Column struct {
 	Default   interface{} // default value.
 	Enums     []string    // enum values.
 	indexes   Indexes     // linked indexes.
-	foreign   *ForeignKey // linked foreign-key.
 }
 
 // UniqueKey returns boolean indicates if this column is a unique key.
@@ -339,11 +344,12 @@ func (r ReferenceOption) ConstName() string {
 
 // Index definition for table index.
 type Index struct {
-	Name    string    // index name.
-	Unique  bool      // uniqueness.
-	Columns []*Column // actual table columns.
-	columns []string  // columns loaded from query scan.
-	primary bool      // primary key index.
+	Name     string    // index name.
+	Unique   bool      // uniqueness.
+	Columns  []*Column // actual table columns.
+	columns  []string  // columns loaded from query scan.
+	primary  bool      // primary key index.
+	realname string    // real name in the database (Postgres only).
 }
 
 // Builder returns the query builder for index creation. The DSL is identical in all dialects.
@@ -362,6 +368,20 @@ func (i *Index) Builder(table string) *sql.IndexBuilder {
 func (i *Index) DropBuilder(table string) *sql.DropIndexBuilder {
 	idx := sql.DropIndex(i.Name).Table(table)
 	return idx
+}
+
+// sameAs reports if the index has the same properties
+// as the given index (except the name).
+func (i *Index) sameAs(idx *Index) bool {
+	if i.Unique != idx.Unique || len(i.Columns) != len(idx.Columns) {
+		return false
+	}
+	for j, c := range i.Columns {
+		if c.Name != idx.Columns[j].Name {
+			return false
+		}
+	}
+	return true
 }
 
 // Indexes used for scanning all sql.Rows into a list of indexes, because

--- a/entc/integration/customid/ent/migrate/schema.go
+++ b/entc/integration/customid/ent/migrate/schema.go
@@ -40,7 +40,7 @@ var (
 	// UsersColumns holds the columns for the "users" table.
 	UsersColumns = []*schema.Column{
 		{Name: "id", Type: field.TypeInt, Increment: true},
-		{Name: "parent_id", Type: field.TypeInt, Nullable: true},
+		{Name: "user_children", Type: field.TypeInt, Nullable: true},
 	}
 	// UsersTable holds the schema information for the "users" table.
 	UsersTable = &schema.Table{

--- a/entc/integration/customid/ent/user.go
+++ b/entc/integration/customid/ent/user.go
@@ -21,8 +21,8 @@ type User struct {
 	ID int `json:"id,omitempty"`
 	// Edges holds the relations/edges for other nodes in the graph.
 	// The values are being populated by the UserQuery when eager-loading is set.
-	Edges     UserEdges `json:"edges"`
-	parent_id *int
+	Edges         UserEdges `json:"edges"`
+	user_children *int
 }
 
 // UserEdges holds the relations/edges for other nodes in the graph.
@@ -80,7 +80,7 @@ func (*User) scanValues() []interface{} {
 // fkValues returns the types for scanning foreign-keys values from sql.Rows.
 func (*User) fkValues() []interface{} {
 	return []interface{}{
-		&sql.NullInt64{}, // parent_id
+		&sql.NullInt64{}, // user_children
 	}
 }
 
@@ -99,10 +99,10 @@ func (u *User) assignValues(values ...interface{}) error {
 	values = values[0:]
 	if len(values) == len(user.ForeignKeys) {
 		if value, ok := values[0].(*sql.NullInt64); !ok {
-			return fmt.Errorf("unexpected type %T for edge-field parent_id", value)
+			return fmt.Errorf("unexpected type %T for edge-field user_children", value)
 		} else if value.Valid {
-			u.parent_id = new(int)
-			*u.parent_id = int(value.Int64)
+			u.user_children = new(int)
+			*u.user_children = int(value.Int64)
 		}
 	}
 	return nil

--- a/entc/integration/customid/ent/user/user.go
+++ b/entc/integration/customid/ent/user/user.go
@@ -22,11 +22,11 @@ const (
 	// ParentTable is the table the holds the parent relation/edge.
 	ParentTable = "users"
 	// ParentColumn is the table column denoting the parent relation/edge.
-	ParentColumn = "parent_id"
+	ParentColumn = "user_children"
 	// ChildrenTable is the table the holds the children relation/edge.
 	ChildrenTable = "users"
 	// ChildrenColumn is the table column denoting the children relation/edge.
-	ChildrenColumn = "parent_id"
+	ChildrenColumn = "user_children"
 )
 
 // Columns holds all SQL columns for user fields.
@@ -36,7 +36,7 @@ var Columns = []string{
 
 // ForeignKeys holds the SQL foreign-keys that are owned by the User type.
 var ForeignKeys = []string{
-	"parent_id",
+	"user_children",
 }
 
 var (

--- a/entc/integration/customid/ent/user_query.go
+++ b/entc/integration/customid/ent/user_query.go
@@ -425,7 +425,7 @@ func (uq *UserQuery) sqlAll(ctx context.Context) ([]*User, error) {
 		ids := make([]int, 0, len(nodes))
 		nodeids := make(map[int][]*User)
 		for i := range nodes {
-			if fk := nodes[i].parent_id; fk != nil {
+			if fk := nodes[i].user_children; fk != nil {
 				ids = append(ids, *fk)
 				nodeids[*fk] = append(nodeids[*fk], nodes[i])
 			}
@@ -438,7 +438,7 @@ func (uq *UserQuery) sqlAll(ctx context.Context) ([]*User, error) {
 		for _, n := range neighbors {
 			nodes, ok := nodeids[n.ID]
 			if !ok {
-				return nil, fmt.Errorf(`unexpected foreign-key "parent_id" returned %v`, n.ID)
+				return nil, fmt.Errorf(`unexpected foreign-key "user_children" returned %v`, n.ID)
 			}
 			for i := range nodes {
 				nodes[i].Edges.Parent = n
@@ -462,13 +462,13 @@ func (uq *UserQuery) sqlAll(ctx context.Context) ([]*User, error) {
 			return nil, err
 		}
 		for _, n := range neighbors {
-			fk := n.parent_id
+			fk := n.user_children
 			if fk == nil {
-				return nil, fmt.Errorf(`foreign-key "parent_id" is nil for node %v`, n.ID)
+				return nil, fmt.Errorf(`foreign-key "user_children" is nil for node %v`, n.ID)
 			}
 			node, ok := nodeids[*fk]
 			if !ok {
-				return nil, fmt.Errorf(`unexpected foreign-key "parent_id" returned %v for node %v`, *fk, n.ID)
+				return nil, fmt.Errorf(`unexpected foreign-key "user_children" returned %v for node %v`, *fk, n.ID)
 			}
 			node.Edges.Children = append(node.Edges.Children, n)
 		}

--- a/entc/integration/ent/card.go
+++ b/entc/integration/ent/card.go
@@ -32,8 +32,8 @@ type Card struct {
 	Name string `json:"name,omitempty"`
 	// Edges holds the relations/edges for other nodes in the graph.
 	// The values are being populated by the CardQuery when eager-loading is set.
-	Edges    CardEdges `json:"edges"`
-	owner_id *string
+	Edges     CardEdges `json:"edges"`
+	user_card *string
 
 	// StaticField defined by templates.
 	StaticField string `json:"boring,omitempty"`
@@ -87,7 +87,7 @@ func (*Card) scanValues() []interface{} {
 // fkValues returns the types for scanning foreign-keys values from sql.Rows.
 func (*Card) fkValues() []interface{} {
 	return []interface{}{
-		&sql.NullInt64{}, // owner_id
+		&sql.NullInt64{}, // user_card
 	}
 }
 
@@ -126,10 +126,10 @@ func (c *Card) assignValues(values ...interface{}) error {
 	values = values[4:]
 	if len(values) == len(card.ForeignKeys) {
 		if value, ok := values[0].(*sql.NullInt64); !ok {
-			return fmt.Errorf("unexpected type %T for edge-field owner_id", value)
+			return fmt.Errorf("unexpected type %T for edge-field user_card", value)
 		} else if value.Valid {
-			c.owner_id = new(string)
-			*c.owner_id = strconv.FormatInt(value.Int64, 10)
+			c.user_card = new(string)
+			*c.user_card = strconv.FormatInt(value.Int64, 10)
 		}
 	}
 	return nil

--- a/entc/integration/ent/card/card.go
+++ b/entc/integration/ent/card/card.go
@@ -35,7 +35,7 @@ const (
 	// It exists in this package in order to avoid circular dependency with the "user" package.
 	OwnerInverseTable = "users"
 	// OwnerColumn is the table column denoting the owner relation/edge.
-	OwnerColumn = "owner_id"
+	OwnerColumn = "user_card"
 	// SpecTable is the table the holds the spec relation/edge. The primary key declared below.
 	SpecTable = "spec_card"
 	// SpecInverseTable is the table name for the Spec entity.
@@ -54,7 +54,7 @@ var Columns = []string{
 
 // ForeignKeys holds the SQL foreign-keys that are owned by the Card type.
 var ForeignKeys = []string{
-	"owner_id",
+	"user_card",
 }
 
 var (

--- a/entc/integration/ent/card_query.go
+++ b/entc/integration/ent/card_query.go
@@ -363,7 +363,7 @@ func (cq *CardQuery) sqlAll(ctx context.Context) ([]*Card, error) {
 		ids := make([]string, 0, len(nodes))
 		nodeids := make(map[string][]*Card)
 		for i := range nodes {
-			if fk := nodes[i].owner_id; fk != nil {
+			if fk := nodes[i].user_card; fk != nil {
 				ids = append(ids, *fk)
 				nodeids[*fk] = append(nodeids[*fk], nodes[i])
 			}
@@ -376,7 +376,7 @@ func (cq *CardQuery) sqlAll(ctx context.Context) ([]*Card, error) {
 		for _, n := range neighbors {
 			nodes, ok := nodeids[n.ID]
 			if !ok {
-				return nil, fmt.Errorf(`unexpected foreign-key "owner_id" returned %v`, n.ID)
+				return nil, fmt.Errorf(`unexpected foreign-key "user_card" returned %v`, n.ID)
 			}
 			for i := range nodes {
 				nodes[i].Edges.Owner = n

--- a/entc/integration/ent/file.go
+++ b/entc/integration/ent/file.go
@@ -32,10 +32,10 @@ type File struct {
 	Group string `json:"group,omitempty"`
 	// Edges holds the relations/edges for other nodes in the graph.
 	// The values are being populated by the FileQuery when eager-loading is set.
-	Edges         FileEdges `json:"edges"`
-	type_id       *string
-	group_file_id *string
-	owner_id      *string
+	Edges           FileEdges `json:"edges"`
+	file_type_files *string
+	group_files     *string
+	user_files      *string
 }
 
 // FileEdges holds the relations/edges for other nodes in the graph.
@@ -91,9 +91,9 @@ func (*File) scanValues() []interface{} {
 // fkValues returns the types for scanning foreign-keys values from sql.Rows.
 func (*File) fkValues() []interface{} {
 	return []interface{}{
-		&sql.NullInt64{}, // type_id
-		&sql.NullInt64{}, // group_file_id
-		&sql.NullInt64{}, // owner_id
+		&sql.NullInt64{}, // file_type_files
+		&sql.NullInt64{}, // group_files
+		&sql.NullInt64{}, // user_files
 	}
 }
 
@@ -133,22 +133,22 @@ func (f *File) assignValues(values ...interface{}) error {
 	values = values[4:]
 	if len(values) == len(file.ForeignKeys) {
 		if value, ok := values[0].(*sql.NullInt64); !ok {
-			return fmt.Errorf("unexpected type %T for edge-field type_id", value)
+			return fmt.Errorf("unexpected type %T for edge-field file_type_files", value)
 		} else if value.Valid {
-			f.type_id = new(string)
-			*f.type_id = strconv.FormatInt(value.Int64, 10)
+			f.file_type_files = new(string)
+			*f.file_type_files = strconv.FormatInt(value.Int64, 10)
 		}
 		if value, ok := values[1].(*sql.NullInt64); !ok {
-			return fmt.Errorf("unexpected type %T for edge-field group_file_id", value)
+			return fmt.Errorf("unexpected type %T for edge-field group_files", value)
 		} else if value.Valid {
-			f.group_file_id = new(string)
-			*f.group_file_id = strconv.FormatInt(value.Int64, 10)
+			f.group_files = new(string)
+			*f.group_files = strconv.FormatInt(value.Int64, 10)
 		}
 		if value, ok := values[2].(*sql.NullInt64); !ok {
-			return fmt.Errorf("unexpected type %T for edge-field owner_id", value)
+			return fmt.Errorf("unexpected type %T for edge-field user_files", value)
 		} else if value.Valid {
-			f.owner_id = new(string)
-			*f.owner_id = strconv.FormatInt(value.Int64, 10)
+			f.user_files = new(string)
+			*f.user_files = strconv.FormatInt(value.Int64, 10)
 		}
 	}
 	return nil

--- a/entc/integration/ent/file/file.go
+++ b/entc/integration/ent/file/file.go
@@ -32,14 +32,14 @@ const (
 	// It exists in this package in order to avoid circular dependency with the "user" package.
 	OwnerInverseTable = "users"
 	// OwnerColumn is the table column denoting the owner relation/edge.
-	OwnerColumn = "owner_id"
+	OwnerColumn = "user_files"
 	// TypeTable is the table the holds the type relation/edge.
 	TypeTable = "files"
 	// TypeInverseTable is the table name for the FileType entity.
 	// It exists in this package in order to avoid circular dependency with the "filetype" package.
 	TypeInverseTable = "file_types"
 	// TypeColumn is the table column denoting the type relation/edge.
-	TypeColumn = "type_id"
+	TypeColumn = "file_type_files"
 )
 
 // Columns holds all SQL columns for file fields.
@@ -53,9 +53,9 @@ var Columns = []string{
 
 // ForeignKeys holds the SQL foreign-keys that are owned by the File type.
 var ForeignKeys = []string{
-	"type_id",
-	"group_file_id",
-	"owner_id",
+	"file_type_files",
+	"group_files",
+	"user_files",
 }
 
 var (

--- a/entc/integration/ent/file_query.go
+++ b/entc/integration/ent/file_query.go
@@ -361,7 +361,7 @@ func (fq *FileQuery) sqlAll(ctx context.Context) ([]*File, error) {
 		ids := make([]string, 0, len(nodes))
 		nodeids := make(map[string][]*File)
 		for i := range nodes {
-			if fk := nodes[i].owner_id; fk != nil {
+			if fk := nodes[i].user_files; fk != nil {
 				ids = append(ids, *fk)
 				nodeids[*fk] = append(nodeids[*fk], nodes[i])
 			}
@@ -374,7 +374,7 @@ func (fq *FileQuery) sqlAll(ctx context.Context) ([]*File, error) {
 		for _, n := range neighbors {
 			nodes, ok := nodeids[n.ID]
 			if !ok {
-				return nil, fmt.Errorf(`unexpected foreign-key "owner_id" returned %v`, n.ID)
+				return nil, fmt.Errorf(`unexpected foreign-key "user_files" returned %v`, n.ID)
 			}
 			for i := range nodes {
 				nodes[i].Edges.Owner = n
@@ -386,7 +386,7 @@ func (fq *FileQuery) sqlAll(ctx context.Context) ([]*File, error) {
 		ids := make([]string, 0, len(nodes))
 		nodeids := make(map[string][]*File)
 		for i := range nodes {
-			if fk := nodes[i].type_id; fk != nil {
+			if fk := nodes[i].file_type_files; fk != nil {
 				ids = append(ids, *fk)
 				nodeids[*fk] = append(nodeids[*fk], nodes[i])
 			}
@@ -399,7 +399,7 @@ func (fq *FileQuery) sqlAll(ctx context.Context) ([]*File, error) {
 		for _, n := range neighbors {
 			nodes, ok := nodeids[n.ID]
 			if !ok {
-				return nil, fmt.Errorf(`unexpected foreign-key "type_id" returned %v`, n.ID)
+				return nil, fmt.Errorf(`unexpected foreign-key "file_type_files" returned %v`, n.ID)
 			}
 			for i := range nodes {
 				nodes[i].Edges.Type = n

--- a/entc/integration/ent/filetype/filetype.go
+++ b/entc/integration/ent/filetype/filetype.go
@@ -22,7 +22,7 @@ const (
 	// It exists in this package in order to avoid circular dependency with the "file" package.
 	FilesInverseTable = "files"
 	// FilesColumn is the table column denoting the files relation/edge.
-	FilesColumn = "type_id"
+	FilesColumn = "file_type_files"
 )
 
 // Columns holds all SQL columns for filetype fields.

--- a/entc/integration/ent/filetype_query.go
+++ b/entc/integration/ent/filetype_query.go
@@ -342,13 +342,13 @@ func (ftq *FileTypeQuery) sqlAll(ctx context.Context) ([]*FileType, error) {
 			return nil, err
 		}
 		for _, n := range neighbors {
-			fk := n.type_id
+			fk := n.file_type_files
 			if fk == nil {
-				return nil, fmt.Errorf(`foreign-key "type_id" is nil for node %v`, n.ID)
+				return nil, fmt.Errorf(`foreign-key "file_type_files" is nil for node %v`, n.ID)
 			}
 			node, ok := nodeids[*fk]
 			if !ok {
-				return nil, fmt.Errorf(`unexpected foreign-key "type_id" returned %v for node %v`, *fk, n.ID)
+				return nil, fmt.Errorf(`unexpected foreign-key "file_type_files" returned %v for node %v`, *fk, n.ID)
 			}
 			node.Edges.Files = append(node.Edges.Files, n)
 		}

--- a/entc/integration/ent/group.go
+++ b/entc/integration/ent/group.go
@@ -34,8 +34,8 @@ type Group struct {
 	Name string `json:"name,omitempty"`
 	// Edges holds the relations/edges for other nodes in the graph.
 	// The values are being populated by the GroupQuery when eager-loading is set.
-	Edges   GroupEdges `json:"edges"`
-	info_id *string
+	Edges      GroupEdges `json:"edges"`
+	group_info *string
 }
 
 // GroupEdges holds the relations/edges for other nodes in the graph.
@@ -109,7 +109,7 @@ func (*Group) scanValues() []interface{} {
 // fkValues returns the types for scanning foreign-keys values from sql.Rows.
 func (*Group) fkValues() []interface{} {
 	return []interface{}{
-		&sql.NullInt64{}, // info_id
+		&sql.NullInt64{}, // group_info
 	}
 }
 
@@ -154,10 +154,10 @@ func (gr *Group) assignValues(values ...interface{}) error {
 	values = values[5:]
 	if len(values) == len(group.ForeignKeys) {
 		if value, ok := values[0].(*sql.NullInt64); !ok {
-			return fmt.Errorf("unexpected type %T for edge-field info_id", value)
+			return fmt.Errorf("unexpected type %T for edge-field group_info", value)
 		} else if value.Valid {
-			gr.info_id = new(string)
-			*gr.info_id = strconv.FormatInt(value.Int64, 10)
+			gr.group_info = new(string)
+			*gr.group_info = strconv.FormatInt(value.Int64, 10)
 		}
 	}
 	return nil

--- a/entc/integration/ent/group/group.go
+++ b/entc/integration/ent/group/group.go
@@ -34,14 +34,14 @@ const (
 	// It exists in this package in order to avoid circular dependency with the "file" package.
 	FilesInverseTable = "files"
 	// FilesColumn is the table column denoting the files relation/edge.
-	FilesColumn = "group_file_id"
+	FilesColumn = "group_files"
 	// BlockedTable is the table the holds the blocked relation/edge.
 	BlockedTable = "users"
 	// BlockedInverseTable is the table name for the User entity.
 	// It exists in this package in order to avoid circular dependency with the "user" package.
 	BlockedInverseTable = "users"
 	// BlockedColumn is the table column denoting the blocked relation/edge.
-	BlockedColumn = "group_blocked_id"
+	BlockedColumn = "group_blocked"
 	// UsersTable is the table the holds the users relation/edge. The primary key declared below.
 	UsersTable = "user_groups"
 	// UsersInverseTable is the table name for the User entity.
@@ -53,7 +53,7 @@ const (
 	// It exists in this package in order to avoid circular dependency with the "groupinfo" package.
 	InfoInverseTable = "group_infos"
 	// InfoColumn is the table column denoting the info relation/edge.
-	InfoColumn = "info_id"
+	InfoColumn = "group_info"
 )
 
 // Columns holds all SQL columns for group fields.
@@ -68,7 +68,7 @@ var Columns = []string{
 
 // ForeignKeys holds the SQL foreign-keys that are owned by the Group type.
 var ForeignKeys = []string{
-	"info_id",
+	"group_info",
 }
 
 var (

--- a/entc/integration/ent/group_query.go
+++ b/entc/integration/ent/group_query.go
@@ -430,13 +430,13 @@ func (gq *GroupQuery) sqlAll(ctx context.Context) ([]*Group, error) {
 			return nil, err
 		}
 		for _, n := range neighbors {
-			fk := n.group_file_id
+			fk := n.group_files
 			if fk == nil {
-				return nil, fmt.Errorf(`foreign-key "group_file_id" is nil for node %v`, n.ID)
+				return nil, fmt.Errorf(`foreign-key "group_files" is nil for node %v`, n.ID)
 			}
 			node, ok := nodeids[*fk]
 			if !ok {
-				return nil, fmt.Errorf(`unexpected foreign-key "group_file_id" returned %v for node %v`, *fk, n.ID)
+				return nil, fmt.Errorf(`unexpected foreign-key "group_files" returned %v for node %v`, *fk, n.ID)
 			}
 			node.Edges.Files = append(node.Edges.Files, n)
 		}
@@ -462,13 +462,13 @@ func (gq *GroupQuery) sqlAll(ctx context.Context) ([]*Group, error) {
 			return nil, err
 		}
 		for _, n := range neighbors {
-			fk := n.group_blocked_id
+			fk := n.group_blocked
 			if fk == nil {
-				return nil, fmt.Errorf(`foreign-key "group_blocked_id" is nil for node %v`, n.ID)
+				return nil, fmt.Errorf(`foreign-key "group_blocked" is nil for node %v`, n.ID)
 			}
 			node, ok := nodeids[*fk]
 			if !ok {
-				return nil, fmt.Errorf(`unexpected foreign-key "group_blocked_id" returned %v for node %v`, *fk, n.ID)
+				return nil, fmt.Errorf(`unexpected foreign-key "group_blocked" returned %v for node %v`, *fk, n.ID)
 			}
 			node.Edges.Blocked = append(node.Edges.Blocked, n)
 		}
@@ -541,7 +541,7 @@ func (gq *GroupQuery) sqlAll(ctx context.Context) ([]*Group, error) {
 		ids := make([]string, 0, len(nodes))
 		nodeids := make(map[string][]*Group)
 		for i := range nodes {
-			if fk := nodes[i].info_id; fk != nil {
+			if fk := nodes[i].group_info; fk != nil {
 				ids = append(ids, *fk)
 				nodeids[*fk] = append(nodeids[*fk], nodes[i])
 			}
@@ -554,7 +554,7 @@ func (gq *GroupQuery) sqlAll(ctx context.Context) ([]*Group, error) {
 		for _, n := range neighbors {
 			nodes, ok := nodeids[n.ID]
 			if !ok {
-				return nil, fmt.Errorf(`unexpected foreign-key "info_id" returned %v`, n.ID)
+				return nil, fmt.Errorf(`unexpected foreign-key "group_info" returned %v`, n.ID)
 			}
 			for i := range nodes {
 				nodes[i].Edges.Info = n

--- a/entc/integration/ent/groupinfo/groupinfo.go
+++ b/entc/integration/ent/groupinfo/groupinfo.go
@@ -28,7 +28,7 @@ const (
 	// It exists in this package in order to avoid circular dependency with the "group" package.
 	GroupsInverseTable = "groups"
 	// GroupsColumn is the table column denoting the groups relation/edge.
-	GroupsColumn = "info_id"
+	GroupsColumn = "group_info"
 )
 
 // Columns holds all SQL columns for groupinfo fields.

--- a/entc/integration/ent/groupinfo_query.go
+++ b/entc/integration/ent/groupinfo_query.go
@@ -342,13 +342,13 @@ func (giq *GroupInfoQuery) sqlAll(ctx context.Context) ([]*GroupInfo, error) {
 			return nil, err
 		}
 		for _, n := range neighbors {
-			fk := n.info_id
+			fk := n.group_info
 			if fk == nil {
-				return nil, fmt.Errorf(`foreign-key "info_id" is nil for node %v`, n.ID)
+				return nil, fmt.Errorf(`foreign-key "group_info" is nil for node %v`, n.ID)
 			}
 			node, ok := nodeids[*fk]
 			if !ok {
-				return nil, fmt.Errorf(`unexpected foreign-key "info_id" returned %v for node %v`, *fk, n.ID)
+				return nil, fmt.Errorf(`unexpected foreign-key "group_info" returned %v for node %v`, *fk, n.ID)
 			}
 			node.Edges.Groups = append(node.Edges.Groups, n)
 		}

--- a/entc/integration/ent/migrate/schema.go
+++ b/entc/integration/ent/migrate/schema.go
@@ -24,7 +24,7 @@ var (
 		{Name: "update_time", Type: field.TypeTime},
 		{Name: "number", Type: field.TypeString},
 		{Name: "name", Type: field.TypeString, Nullable: true},
-		{Name: "owner_id", Type: field.TypeInt, Unique: true, Nullable: true},
+		{Name: "user_card", Type: field.TypeInt, Unique: true, Nullable: true},
 	}
 	// CardsTable holds the schema information for the "cards" table.
 	CardsTable = &schema.Table{
@@ -95,9 +95,9 @@ var (
 		{Name: "name", Type: field.TypeString},
 		{Name: "user", Type: field.TypeString, Nullable: true},
 		{Name: "group", Type: field.TypeString, Nullable: true},
-		{Name: "type_id", Type: field.TypeInt, Nullable: true},
-		{Name: "group_file_id", Type: field.TypeInt, Nullable: true},
-		{Name: "owner_id", Type: field.TypeInt, Nullable: true},
+		{Name: "file_type_files", Type: field.TypeInt, Nullable: true},
+		{Name: "group_files", Type: field.TypeInt, Nullable: true},
+		{Name: "user_files", Type: field.TypeInt, Nullable: true},
 	}
 	// FilesTable holds the schema information for the "files" table.
 	FilesTable = &schema.Table{
@@ -139,17 +139,17 @@ var (
 				Columns: []*schema.Column{FilesColumns[2], FilesColumns[3]},
 			},
 			{
-				Name:    "file_owner_id_type_id",
+				Name:    "file_user_files_file_type_files",
 				Unique:  false,
 				Columns: []*schema.Column{FilesColumns[7], FilesColumns[5]},
 			},
 			{
-				Name:    "file_name_owner_id_type_id",
+				Name:    "file_name_user_files_file_type_files",
 				Unique:  true,
 				Columns: []*schema.Column{FilesColumns[2], FilesColumns[7], FilesColumns[5]},
 			},
 			{
-				Name:    "file_name_owner_id",
+				Name:    "file_name_user_files",
 				Unique:  false,
 				Columns: []*schema.Column{FilesColumns[2], FilesColumns[7]},
 			},
@@ -175,7 +175,7 @@ var (
 		{Name: "type", Type: field.TypeString, Nullable: true, Size: 255},
 		{Name: "max_users", Type: field.TypeInt, Nullable: true, Default: group.DefaultMaxUsers},
 		{Name: "name", Type: field.TypeString},
-		{Name: "info_id", Type: field.TypeInt, Nullable: true},
+		{Name: "group_info", Type: field.TypeInt, Nullable: true},
 	}
 	// GroupsTable holds the schema information for the "groups" table.
 	GroupsTable = &schema.Table{
@@ -220,7 +220,7 @@ var (
 	NodesColumns = []*schema.Column{
 		{Name: "id", Type: field.TypeInt, Increment: true},
 		{Name: "value", Type: field.TypeInt, Nullable: true},
-		{Name: "prev_id", Type: field.TypeInt, Unique: true, Nullable: true},
+		{Name: "node_next", Type: field.TypeInt, Unique: true, Nullable: true},
 	}
 	// NodesTable holds the schema information for the "nodes" table.
 	NodesTable = &schema.Table{
@@ -241,8 +241,8 @@ var (
 	PetsColumns = []*schema.Column{
 		{Name: "id", Type: field.TypeInt, Increment: true},
 		{Name: "name", Type: field.TypeString},
-		{Name: "owner_id", Type: field.TypeInt, Nullable: true},
-		{Name: "team_id", Type: field.TypeInt, Unique: true, Nullable: true},
+		{Name: "user_pets", Type: field.TypeInt, Nullable: true},
+		{Name: "user_team", Type: field.TypeInt, Unique: true, Nullable: true},
 	}
 	// PetsTable holds the schema information for the "pets" table.
 	PetsTable = &schema.Table{
@@ -267,7 +267,7 @@ var (
 		},
 		Indexes: []*schema.Index{
 			{
-				Name:    "pet_name_owner_id",
+				Name:    "pet_name_user_pets",
 				Unique:  false,
 				Columns: []*schema.Column{PetsColumns[1], PetsColumns[2]},
 			},
@@ -295,9 +295,9 @@ var (
 		{Name: "phone", Type: field.TypeString, Unique: true, Nullable: true},
 		{Name: "password", Type: field.TypeString, Nullable: true},
 		{Name: "role", Type: field.TypeEnum, Enums: []string{"user", "admin"}, Default: user.DefaultRole},
-		{Name: "group_blocked_id", Type: field.TypeInt, Nullable: true},
-		{Name: "user_spouse_id", Type: field.TypeInt, Unique: true, Nullable: true},
-		{Name: "parent_id", Type: field.TypeInt, Nullable: true},
+		{Name: "group_blocked", Type: field.TypeInt, Nullable: true},
+		{Name: "user_spouse", Type: field.TypeInt, Unique: true, Nullable: true},
+		{Name: "user_parent", Type: field.TypeInt, Nullable: true},
 	}
 	// UsersTable holds the schema information for the "users" table.
 	UsersTable = &schema.Table{

--- a/entc/integration/ent/node.go
+++ b/entc/integration/ent/node.go
@@ -24,8 +24,8 @@ type Node struct {
 	Value int `json:"value,omitempty"`
 	// Edges holds the relations/edges for other nodes in the graph.
 	// The values are being populated by the NodeQuery when eager-loading is set.
-	Edges   NodeEdges `json:"edges"`
-	prev_id *string
+	Edges     NodeEdges `json:"edges"`
+	node_next *string
 }
 
 // NodeEdges holds the relations/edges for other nodes in the graph.
@@ -78,7 +78,7 @@ func (*Node) scanValues() []interface{} {
 // fkValues returns the types for scanning foreign-keys values from sql.Rows.
 func (*Node) fkValues() []interface{} {
 	return []interface{}{
-		&sql.NullInt64{}, // prev_id
+		&sql.NullInt64{}, // node_next
 	}
 }
 
@@ -102,10 +102,10 @@ func (n *Node) assignValues(values ...interface{}) error {
 	values = values[1:]
 	if len(values) == len(node.ForeignKeys) {
 		if value, ok := values[0].(*sql.NullInt64); !ok {
-			return fmt.Errorf("unexpected type %T for edge-field prev_id", value)
+			return fmt.Errorf("unexpected type %T for edge-field node_next", value)
 		} else if value.Valid {
-			n.prev_id = new(string)
-			*n.prev_id = strconv.FormatInt(value.Int64, 10)
+			n.node_next = new(string)
+			*n.node_next = strconv.FormatInt(value.Int64, 10)
 		}
 	}
 	return nil

--- a/entc/integration/ent/node/node.go
+++ b/entc/integration/ent/node/node.go
@@ -19,11 +19,11 @@ const (
 	// PrevTable is the table the holds the prev relation/edge.
 	PrevTable = "nodes"
 	// PrevColumn is the table column denoting the prev relation/edge.
-	PrevColumn = "prev_id"
+	PrevColumn = "node_next"
 	// NextTable is the table the holds the next relation/edge.
 	NextTable = "nodes"
 	// NextColumn is the table column denoting the next relation/edge.
-	NextColumn = "prev_id"
+	NextColumn = "node_next"
 )
 
 // Columns holds all SQL columns for node fields.
@@ -34,5 +34,5 @@ var Columns = []string{
 
 // ForeignKeys holds the SQL foreign-keys that are owned by the Node type.
 var ForeignKeys = []string{
-	"prev_id",
+	"node_next",
 }

--- a/entc/integration/ent/node_query.go
+++ b/entc/integration/ent/node_query.go
@@ -361,7 +361,7 @@ func (nq *NodeQuery) sqlAll(ctx context.Context) ([]*Node, error) {
 		ids := make([]string, 0, len(nodes))
 		nodeids := make(map[string][]*Node)
 		for i := range nodes {
-			if fk := nodes[i].prev_id; fk != nil {
+			if fk := nodes[i].node_next; fk != nil {
 				ids = append(ids, *fk)
 				nodeids[*fk] = append(nodeids[*fk], nodes[i])
 			}
@@ -374,7 +374,7 @@ func (nq *NodeQuery) sqlAll(ctx context.Context) ([]*Node, error) {
 		for _, n := range neighbors {
 			nodes, ok := nodeids[n.ID]
 			if !ok {
-				return nil, fmt.Errorf(`unexpected foreign-key "prev_id" returned %v`, n.ID)
+				return nil, fmt.Errorf(`unexpected foreign-key "node_next" returned %v`, n.ID)
 			}
 			for i := range nodes {
 				nodes[i].Edges.Prev = n
@@ -402,13 +402,13 @@ func (nq *NodeQuery) sqlAll(ctx context.Context) ([]*Node, error) {
 			return nil, err
 		}
 		for _, n := range neighbors {
-			fk := n.prev_id
+			fk := n.node_next
 			if fk == nil {
-				return nil, fmt.Errorf(`foreign-key "prev_id" is nil for node %v`, n.ID)
+				return nil, fmt.Errorf(`foreign-key "node_next" is nil for node %v`, n.ID)
 			}
 			node, ok := nodeids[*fk]
 			if !ok {
-				return nil, fmt.Errorf(`unexpected foreign-key "prev_id" returned %v for node %v`, *fk, n.ID)
+				return nil, fmt.Errorf(`unexpected foreign-key "node_next" returned %v for node %v`, *fk, n.ID)
 			}
 			node.Edges.Next = n
 		}

--- a/entc/integration/ent/pet.go
+++ b/entc/integration/ent/pet.go
@@ -25,9 +25,9 @@ type Pet struct {
 	Name string `json:"name,omitempty"`
 	// Edges holds the relations/edges for other nodes in the graph.
 	// The values are being populated by the PetQuery when eager-loading is set.
-	Edges    PetEdges `json:"edges"`
-	owner_id *string
-	team_id  *string
+	Edges     PetEdges `json:"edges"`
+	user_pets *string
+	user_team *string
 }
 
 // PetEdges holds the relations/edges for other nodes in the graph.
@@ -80,8 +80,8 @@ func (*Pet) scanValues() []interface{} {
 // fkValues returns the types for scanning foreign-keys values from sql.Rows.
 func (*Pet) fkValues() []interface{} {
 	return []interface{}{
-		&sql.NullInt64{}, // owner_id
-		&sql.NullInt64{}, // team_id
+		&sql.NullInt64{}, // user_pets
+		&sql.NullInt64{}, // user_team
 	}
 }
 
@@ -105,16 +105,16 @@ func (pe *Pet) assignValues(values ...interface{}) error {
 	values = values[1:]
 	if len(values) == len(pet.ForeignKeys) {
 		if value, ok := values[0].(*sql.NullInt64); !ok {
-			return fmt.Errorf("unexpected type %T for edge-field owner_id", value)
+			return fmt.Errorf("unexpected type %T for edge-field user_pets", value)
 		} else if value.Valid {
-			pe.owner_id = new(string)
-			*pe.owner_id = strconv.FormatInt(value.Int64, 10)
+			pe.user_pets = new(string)
+			*pe.user_pets = strconv.FormatInt(value.Int64, 10)
 		}
 		if value, ok := values[1].(*sql.NullInt64); !ok {
-			return fmt.Errorf("unexpected type %T for edge-field team_id", value)
+			return fmt.Errorf("unexpected type %T for edge-field user_team", value)
 		} else if value.Valid {
-			pe.team_id = new(string)
-			*pe.team_id = strconv.FormatInt(value.Int64, 10)
+			pe.user_team = new(string)
+			*pe.user_team = strconv.FormatInt(value.Int64, 10)
 		}
 	}
 	return nil

--- a/entc/integration/ent/pet/pet.go
+++ b/entc/integration/ent/pet/pet.go
@@ -22,14 +22,14 @@ const (
 	// It exists in this package in order to avoid circular dependency with the "user" package.
 	TeamInverseTable = "users"
 	// TeamColumn is the table column denoting the team relation/edge.
-	TeamColumn = "team_id"
+	TeamColumn = "user_team"
 	// OwnerTable is the table the holds the owner relation/edge.
 	OwnerTable = "pets"
 	// OwnerInverseTable is the table name for the User entity.
 	// It exists in this package in order to avoid circular dependency with the "user" package.
 	OwnerInverseTable = "users"
 	// OwnerColumn is the table column denoting the owner relation/edge.
-	OwnerColumn = "owner_id"
+	OwnerColumn = "user_pets"
 )
 
 // Columns holds all SQL columns for pet fields.
@@ -40,6 +40,6 @@ var Columns = []string{
 
 // ForeignKeys holds the SQL foreign-keys that are owned by the Pet type.
 var ForeignKeys = []string{
-	"owner_id",
-	"team_id",
+	"user_pets",
+	"user_team",
 }

--- a/entc/integration/ent/pet_query.go
+++ b/entc/integration/ent/pet_query.go
@@ -360,7 +360,7 @@ func (pq *PetQuery) sqlAll(ctx context.Context) ([]*Pet, error) {
 		ids := make([]string, 0, len(nodes))
 		nodeids := make(map[string][]*Pet)
 		for i := range nodes {
-			if fk := nodes[i].team_id; fk != nil {
+			if fk := nodes[i].user_team; fk != nil {
 				ids = append(ids, *fk)
 				nodeids[*fk] = append(nodeids[*fk], nodes[i])
 			}
@@ -373,7 +373,7 @@ func (pq *PetQuery) sqlAll(ctx context.Context) ([]*Pet, error) {
 		for _, n := range neighbors {
 			nodes, ok := nodeids[n.ID]
 			if !ok {
-				return nil, fmt.Errorf(`unexpected foreign-key "team_id" returned %v`, n.ID)
+				return nil, fmt.Errorf(`unexpected foreign-key "user_team" returned %v`, n.ID)
 			}
 			for i := range nodes {
 				nodes[i].Edges.Team = n
@@ -385,7 +385,7 @@ func (pq *PetQuery) sqlAll(ctx context.Context) ([]*Pet, error) {
 		ids := make([]string, 0, len(nodes))
 		nodeids := make(map[string][]*Pet)
 		for i := range nodes {
-			if fk := nodes[i].owner_id; fk != nil {
+			if fk := nodes[i].user_pets; fk != nil {
 				ids = append(ids, *fk)
 				nodeids[*fk] = append(nodeids[*fk], nodes[i])
 			}
@@ -398,7 +398,7 @@ func (pq *PetQuery) sqlAll(ctx context.Context) ([]*Pet, error) {
 		for _, n := range neighbors {
 			nodes, ok := nodeids[n.ID]
 			if !ok {
-				return nil, fmt.Errorf(`unexpected foreign-key "owner_id" returned %v`, n.ID)
+				return nil, fmt.Errorf(`unexpected foreign-key "user_pets" returned %v`, n.ID)
 			}
 			for i := range nodes {
 				nodes[i].Edges.Owner = n

--- a/entc/integration/ent/user.go
+++ b/entc/integration/ent/user.go
@@ -40,10 +40,10 @@ type User struct {
 	Role user.Role `json:"role,omitempty"`
 	// Edges holds the relations/edges for other nodes in the graph.
 	// The values are being populated by the UserQuery when eager-loading is set.
-	Edges            UserEdges `json:"edges"`
-	group_blocked_id *string
-	user_spouse_id   *string
-	parent_id        *string
+	Edges         UserEdges `json:"edges"`
+	group_blocked *string
+	user_spouse   *string
+	user_parent   *string
 }
 
 // UserEdges holds the relations/edges for other nodes in the graph.
@@ -212,9 +212,9 @@ func (*User) scanValues() []interface{} {
 // fkValues returns the types for scanning foreign-keys values from sql.Rows.
 func (*User) fkValues() []interface{} {
 	return []interface{}{
-		&sql.NullInt64{}, // group_blocked_id
-		&sql.NullInt64{}, // user_spouse_id
-		&sql.NullInt64{}, // parent_id
+		&sql.NullInt64{}, // group_blocked
+		&sql.NullInt64{}, // user_spouse
+		&sql.NullInt64{}, // user_parent
 	}
 }
 
@@ -273,22 +273,22 @@ func (u *User) assignValues(values ...interface{}) error {
 	values = values[8:]
 	if len(values) == len(user.ForeignKeys) {
 		if value, ok := values[0].(*sql.NullInt64); !ok {
-			return fmt.Errorf("unexpected type %T for edge-field group_blocked_id", value)
+			return fmt.Errorf("unexpected type %T for edge-field group_blocked", value)
 		} else if value.Valid {
-			u.group_blocked_id = new(string)
-			*u.group_blocked_id = strconv.FormatInt(value.Int64, 10)
+			u.group_blocked = new(string)
+			*u.group_blocked = strconv.FormatInt(value.Int64, 10)
 		}
 		if value, ok := values[1].(*sql.NullInt64); !ok {
-			return fmt.Errorf("unexpected type %T for edge-field user_spouse_id", value)
+			return fmt.Errorf("unexpected type %T for edge-field user_spouse", value)
 		} else if value.Valid {
-			u.user_spouse_id = new(string)
-			*u.user_spouse_id = strconv.FormatInt(value.Int64, 10)
+			u.user_spouse = new(string)
+			*u.user_spouse = strconv.FormatInt(value.Int64, 10)
 		}
 		if value, ok := values[2].(*sql.NullInt64); !ok {
-			return fmt.Errorf("unexpected type %T for edge-field parent_id", value)
+			return fmt.Errorf("unexpected type %T for edge-field user_parent", value)
 		} else if value.Valid {
-			u.parent_id = new(string)
-			*u.parent_id = strconv.FormatInt(value.Int64, 10)
+			u.user_parent = new(string)
+			*u.user_parent = strconv.FormatInt(value.Int64, 10)
 		}
 	}
 	return nil

--- a/entc/integration/ent/user/user.go
+++ b/entc/integration/ent/user/user.go
@@ -43,21 +43,21 @@ const (
 	// It exists in this package in order to avoid circular dependency with the "card" package.
 	CardInverseTable = "cards"
 	// CardColumn is the table column denoting the card relation/edge.
-	CardColumn = "owner_id"
+	CardColumn = "user_card"
 	// PetsTable is the table the holds the pets relation/edge.
 	PetsTable = "pets"
 	// PetsInverseTable is the table name for the Pet entity.
 	// It exists in this package in order to avoid circular dependency with the "pet" package.
 	PetsInverseTable = "pets"
 	// PetsColumn is the table column denoting the pets relation/edge.
-	PetsColumn = "owner_id"
+	PetsColumn = "user_pets"
 	// FilesTable is the table the holds the files relation/edge.
 	FilesTable = "files"
 	// FilesInverseTable is the table name for the File entity.
 	// It exists in this package in order to avoid circular dependency with the "file" package.
 	FilesInverseTable = "files"
 	// FilesColumn is the table column denoting the files relation/edge.
-	FilesColumn = "owner_id"
+	FilesColumn = "user_files"
 	// GroupsTable is the table the holds the groups relation/edge. The primary key declared below.
 	GroupsTable = "user_groups"
 	// GroupsInverseTable is the table name for the Group entity.
@@ -75,19 +75,19 @@ const (
 	// It exists in this package in order to avoid circular dependency with the "pet" package.
 	TeamInverseTable = "pets"
 	// TeamColumn is the table column denoting the team relation/edge.
-	TeamColumn = "team_id"
+	TeamColumn = "user_team"
 	// SpouseTable is the table the holds the spouse relation/edge.
 	SpouseTable = "users"
 	// SpouseColumn is the table column denoting the spouse relation/edge.
-	SpouseColumn = "user_spouse_id"
+	SpouseColumn = "user_spouse"
 	// ChildrenTable is the table the holds the children relation/edge.
 	ChildrenTable = "users"
 	// ChildrenColumn is the table column denoting the children relation/edge.
-	ChildrenColumn = "parent_id"
+	ChildrenColumn = "user_parent"
 	// ParentTable is the table the holds the parent relation/edge.
 	ParentTable = "users"
 	// ParentColumn is the table column denoting the parent relation/edge.
-	ParentColumn = "parent_id"
+	ParentColumn = "user_parent"
 )
 
 // Columns holds all SQL columns for user fields.
@@ -105,9 +105,9 @@ var Columns = []string{
 
 // ForeignKeys holds the SQL foreign-keys that are owned by the User type.
 var ForeignKeys = []string{
-	"group_blocked_id",
-	"user_spouse_id",
-	"parent_id",
+	"group_blocked",
+	"user_spouse",
+	"user_parent",
 }
 
 var (

--- a/entc/integration/ent/user_query.go
+++ b/entc/integration/ent/user_query.go
@@ -606,13 +606,13 @@ func (uq *UserQuery) sqlAll(ctx context.Context) ([]*User, error) {
 			return nil, err
 		}
 		for _, n := range neighbors {
-			fk := n.owner_id
+			fk := n.user_card
 			if fk == nil {
-				return nil, fmt.Errorf(`foreign-key "owner_id" is nil for node %v`, n.ID)
+				return nil, fmt.Errorf(`foreign-key "user_card" is nil for node %v`, n.ID)
 			}
 			node, ok := nodeids[*fk]
 			if !ok {
-				return nil, fmt.Errorf(`unexpected foreign-key "owner_id" returned %v for node %v`, *fk, n.ID)
+				return nil, fmt.Errorf(`unexpected foreign-key "user_card" returned %v for node %v`, *fk, n.ID)
 			}
 			node.Edges.Card = n
 		}
@@ -638,13 +638,13 @@ func (uq *UserQuery) sqlAll(ctx context.Context) ([]*User, error) {
 			return nil, err
 		}
 		for _, n := range neighbors {
-			fk := n.owner_id
+			fk := n.user_pets
 			if fk == nil {
-				return nil, fmt.Errorf(`foreign-key "owner_id" is nil for node %v`, n.ID)
+				return nil, fmt.Errorf(`foreign-key "user_pets" is nil for node %v`, n.ID)
 			}
 			node, ok := nodeids[*fk]
 			if !ok {
-				return nil, fmt.Errorf(`unexpected foreign-key "owner_id" returned %v for node %v`, *fk, n.ID)
+				return nil, fmt.Errorf(`unexpected foreign-key "user_pets" returned %v for node %v`, *fk, n.ID)
 			}
 			node.Edges.Pets = append(node.Edges.Pets, n)
 		}
@@ -670,13 +670,13 @@ func (uq *UserQuery) sqlAll(ctx context.Context) ([]*User, error) {
 			return nil, err
 		}
 		for _, n := range neighbors {
-			fk := n.owner_id
+			fk := n.user_files
 			if fk == nil {
-				return nil, fmt.Errorf(`foreign-key "owner_id" is nil for node %v`, n.ID)
+				return nil, fmt.Errorf(`foreign-key "user_files" is nil for node %v`, n.ID)
 			}
 			node, ok := nodeids[*fk]
 			if !ok {
-				return nil, fmt.Errorf(`unexpected foreign-key "owner_id" returned %v for node %v`, *fk, n.ID)
+				return nil, fmt.Errorf(`unexpected foreign-key "user_files" returned %v for node %v`, *fk, n.ID)
 			}
 			node.Edges.Files = append(node.Edges.Files, n)
 		}
@@ -954,13 +954,13 @@ func (uq *UserQuery) sqlAll(ctx context.Context) ([]*User, error) {
 			return nil, err
 		}
 		for _, n := range neighbors {
-			fk := n.team_id
+			fk := n.user_team
 			if fk == nil {
-				return nil, fmt.Errorf(`foreign-key "team_id" is nil for node %v`, n.ID)
+				return nil, fmt.Errorf(`foreign-key "user_team" is nil for node %v`, n.ID)
 			}
 			node, ok := nodeids[*fk]
 			if !ok {
-				return nil, fmt.Errorf(`unexpected foreign-key "team_id" returned %v for node %v`, *fk, n.ID)
+				return nil, fmt.Errorf(`unexpected foreign-key "user_team" returned %v for node %v`, *fk, n.ID)
 			}
 			node.Edges.Team = n
 		}
@@ -970,7 +970,7 @@ func (uq *UserQuery) sqlAll(ctx context.Context) ([]*User, error) {
 		ids := make([]string, 0, len(nodes))
 		nodeids := make(map[string][]*User)
 		for i := range nodes {
-			if fk := nodes[i].user_spouse_id; fk != nil {
+			if fk := nodes[i].user_spouse; fk != nil {
 				ids = append(ids, *fk)
 				nodeids[*fk] = append(nodeids[*fk], nodes[i])
 			}
@@ -983,7 +983,7 @@ func (uq *UserQuery) sqlAll(ctx context.Context) ([]*User, error) {
 		for _, n := range neighbors {
 			nodes, ok := nodeids[n.ID]
 			if !ok {
-				return nil, fmt.Errorf(`unexpected foreign-key "user_spouse_id" returned %v`, n.ID)
+				return nil, fmt.Errorf(`unexpected foreign-key "user_spouse" returned %v`, n.ID)
 			}
 			for i := range nodes {
 				nodes[i].Edges.Spouse = n
@@ -1011,13 +1011,13 @@ func (uq *UserQuery) sqlAll(ctx context.Context) ([]*User, error) {
 			return nil, err
 		}
 		for _, n := range neighbors {
-			fk := n.parent_id
+			fk := n.user_parent
 			if fk == nil {
-				return nil, fmt.Errorf(`foreign-key "parent_id" is nil for node %v`, n.ID)
+				return nil, fmt.Errorf(`foreign-key "user_parent" is nil for node %v`, n.ID)
 			}
 			node, ok := nodeids[*fk]
 			if !ok {
-				return nil, fmt.Errorf(`unexpected foreign-key "parent_id" returned %v for node %v`, *fk, n.ID)
+				return nil, fmt.Errorf(`unexpected foreign-key "user_parent" returned %v for node %v`, *fk, n.ID)
 			}
 			node.Edges.Children = append(node.Edges.Children, n)
 		}
@@ -1027,7 +1027,7 @@ func (uq *UserQuery) sqlAll(ctx context.Context) ([]*User, error) {
 		ids := make([]string, 0, len(nodes))
 		nodeids := make(map[string][]*User)
 		for i := range nodes {
-			if fk := nodes[i].parent_id; fk != nil {
+			if fk := nodes[i].user_parent; fk != nil {
 				ids = append(ids, *fk)
 				nodeids[*fk] = append(nodeids[*fk], nodes[i])
 			}
@@ -1040,7 +1040,7 @@ func (uq *UserQuery) sqlAll(ctx context.Context) ([]*User, error) {
 		for _, n := range neighbors {
 			nodes, ok := nodeids[n.ID]
 			if !ok {
-				return nil, fmt.Errorf(`unexpected foreign-key "parent_id" returned %v`, n.ID)
+				return nil, fmt.Errorf(`unexpected foreign-key "user_parent" returned %v`, n.ID)
 			}
 			for i := range nodes {
 				nodes[i].Edges.Parent = n

--- a/entc/integration/idtype/ent/migrate/schema.go
+++ b/entc/integration/idtype/ent/migrate/schema.go
@@ -16,7 +16,7 @@ var (
 	UsersColumns = []*schema.Column{
 		{Name: "id", Type: field.TypeInt, Increment: true},
 		{Name: "name", Type: field.TypeString},
-		{Name: "user_spouse_id", Type: field.TypeInt, Unique: true, Nullable: true},
+		{Name: "user_spouse", Type: field.TypeInt, Unique: true, Nullable: true},
 	}
 	// UsersTable holds the schema information for the "users" table.
 	UsersTable = &schema.Table{

--- a/entc/integration/idtype/ent/user.go
+++ b/entc/integration/idtype/ent/user.go
@@ -23,8 +23,8 @@ type User struct {
 	Name string `json:"name,omitempty"`
 	// Edges holds the relations/edges for other nodes in the graph.
 	// The values are being populated by the UserQuery when eager-loading is set.
-	Edges          UserEdges `json:"edges"`
-	user_spouse_id *uint64
+	Edges       UserEdges `json:"edges"`
+	user_spouse *uint64
 }
 
 // UserEdges holds the relations/edges for other nodes in the graph.
@@ -83,7 +83,7 @@ func (*User) scanValues() []interface{} {
 // fkValues returns the types for scanning foreign-keys values from sql.Rows.
 func (*User) fkValues() []interface{} {
 	return []interface{}{
-		&sql.NullInt64{}, // user_spouse_id
+		&sql.NullInt64{}, // user_spouse
 	}
 }
 
@@ -107,10 +107,10 @@ func (u *User) assignValues(values ...interface{}) error {
 	values = values[1:]
 	if len(values) == len(user.ForeignKeys) {
 		if value, ok := values[0].(*sql.NullInt64); !ok {
-			return fmt.Errorf("unexpected type %T for edge-field user_spouse_id", value)
+			return fmt.Errorf("unexpected type %T for edge-field user_spouse", value)
 		} else if value.Valid {
-			u.user_spouse_id = new(uint64)
-			*u.user_spouse_id = uint64(value.Int64)
+			u.user_spouse = new(uint64)
+			*u.user_spouse = uint64(value.Int64)
 		}
 	}
 	return nil

--- a/entc/integration/idtype/ent/user/user.go
+++ b/entc/integration/idtype/ent/user/user.go
@@ -19,7 +19,7 @@ const (
 	// SpouseTable is the table the holds the spouse relation/edge.
 	SpouseTable = "users"
 	// SpouseColumn is the table column denoting the spouse relation/edge.
-	SpouseColumn = "user_spouse_id"
+	SpouseColumn = "user_spouse"
 	// FollowersTable is the table the holds the followers relation/edge. The primary key declared below.
 	FollowersTable = "user_following"
 	// FollowingTable is the table the holds the following relation/edge. The primary key declared below.
@@ -34,7 +34,7 @@ var Columns = []string{
 
 // ForeignKeys holds the SQL foreign-keys that are owned by the User type.
 var ForeignKeys = []string{
-	"user_spouse_id",
+	"user_spouse",
 }
 
 var (

--- a/entc/integration/idtype/ent/user_query.go
+++ b/entc/integration/idtype/ent/user_query.go
@@ -385,7 +385,7 @@ func (uq *UserQuery) sqlAll(ctx context.Context) ([]*User, error) {
 		ids := make([]uint64, 0, len(nodes))
 		nodeids := make(map[uint64][]*User)
 		for i := range nodes {
-			if fk := nodes[i].user_spouse_id; fk != nil {
+			if fk := nodes[i].user_spouse; fk != nil {
 				ids = append(ids, *fk)
 				nodeids[*fk] = append(nodeids[*fk], nodes[i])
 			}
@@ -398,7 +398,7 @@ func (uq *UserQuery) sqlAll(ctx context.Context) ([]*User, error) {
 		for _, n := range neighbors {
 			nodes, ok := nodeids[n.ID]
 			if !ok {
-				return nil, fmt.Errorf(`unexpected foreign-key "user_spouse_id" returned %v`, n.ID)
+				return nil, fmt.Errorf(`unexpected foreign-key "user_spouse" returned %v`, n.ID)
 			}
 			for i := range nodes {
 				nodes[i].Edges.Spouse = n

--- a/entc/integration/migrate/entv1/car.go
+++ b/entc/integration/migrate/entv1/car.go
@@ -23,7 +23,7 @@ type Car struct {
 	// Edges holds the relations/edges for other nodes in the graph.
 	// The values are being populated by the CarQuery when eager-loading is set.
 	Edges    CarEdges `json:"edges"`
-	owner_id *int
+	user_car *int
 }
 
 // CarEdges holds the relations/edges for other nodes in the graph.
@@ -59,7 +59,7 @@ func (*Car) scanValues() []interface{} {
 // fkValues returns the types for scanning foreign-keys values from sql.Rows.
 func (*Car) fkValues() []interface{} {
 	return []interface{}{
-		&sql.NullInt64{}, // owner_id
+		&sql.NullInt64{}, // user_car
 	}
 }
 
@@ -78,10 +78,10 @@ func (c *Car) assignValues(values ...interface{}) error {
 	values = values[0:]
 	if len(values) == len(car.ForeignKeys) {
 		if value, ok := values[0].(*sql.NullInt64); !ok {
-			return fmt.Errorf("unexpected type %T for edge-field owner_id", value)
+			return fmt.Errorf("unexpected type %T for edge-field user_car", value)
 		} else if value.Valid {
-			c.owner_id = new(int)
-			*c.owner_id = int(value.Int64)
+			c.user_car = new(int)
+			*c.user_car = int(value.Int64)
 		}
 	}
 	return nil

--- a/entc/integration/migrate/entv1/car/car.go
+++ b/entc/integration/migrate/entv1/car/car.go
@@ -20,7 +20,7 @@ const (
 	// It exists in this package in order to avoid circular dependency with the "user" package.
 	OwnerInverseTable = "users"
 	// OwnerColumn is the table column denoting the owner relation/edge.
-	OwnerColumn = "owner_id"
+	OwnerColumn = "user_car"
 )
 
 // Columns holds all SQL columns for car fields.
@@ -30,5 +30,5 @@ var Columns = []string{
 
 // ForeignKeys holds the SQL foreign-keys that are owned by the Car type.
 var ForeignKeys = []string{
-	"owner_id",
+	"user_car",
 }

--- a/entc/integration/migrate/entv1/car_query.go
+++ b/entc/integration/migrate/entv1/car_query.go
@@ -311,7 +311,7 @@ func (cq *CarQuery) sqlAll(ctx context.Context) ([]*Car, error) {
 		ids := make([]int, 0, len(nodes))
 		nodeids := make(map[int][]*Car)
 		for i := range nodes {
-			if fk := nodes[i].owner_id; fk != nil {
+			if fk := nodes[i].user_car; fk != nil {
 				ids = append(ids, *fk)
 				nodeids[*fk] = append(nodeids[*fk], nodes[i])
 			}
@@ -324,7 +324,7 @@ func (cq *CarQuery) sqlAll(ctx context.Context) ([]*Car, error) {
 		for _, n := range neighbors {
 			nodes, ok := nodeids[n.ID]
 			if !ok {
-				return nil, fmt.Errorf(`unexpected foreign-key "owner_id" returned %v`, n.ID)
+				return nil, fmt.Errorf(`unexpected foreign-key "user_car" returned %v`, n.ID)
 			}
 			for i := range nodes {
 				nodes[i].Edges.Owner = n

--- a/entc/integration/migrate/entv1/migrate/schema.go
+++ b/entc/integration/migrate/entv1/migrate/schema.go
@@ -15,7 +15,7 @@ var (
 	// CarsColumns holds the columns for the "cars" table.
 	CarsColumns = []*schema.Column{
 		{Name: "id", Type: field.TypeInt, Increment: true},
-		{Name: "owner_id", Type: field.TypeInt, Unique: true, Nullable: true},
+		{Name: "user_car", Type: field.TypeInt, Unique: true, Nullable: true},
 	}
 	// CarsTable holds the schema information for the "cars" table.
 	CarsTable = &schema.Table{
@@ -42,8 +42,8 @@ var (
 		{Name: "renamed", Type: field.TypeString, Nullable: true},
 		{Name: "blob", Type: field.TypeBytes, Nullable: true, Size: 255},
 		{Name: "state", Type: field.TypeEnum, Nullable: true, Enums: []string{"logged_in", "logged_out"}},
-		{Name: "parent_id", Type: field.TypeInt, Nullable: true},
-		{Name: "user_spouse_id", Type: field.TypeInt, Unique: true, Nullable: true},
+		{Name: "user_children", Type: field.TypeInt, Nullable: true},
+		{Name: "user_spouse", Type: field.TypeInt, Unique: true, Nullable: true},
 	}
 	// UsersTable holds the schema information for the "users" table.
 	UsersTable = &schema.Table{

--- a/entc/integration/migrate/entv1/user.go
+++ b/entc/integration/migrate/entv1/user.go
@@ -36,9 +36,9 @@ type User struct {
 	State user.State `json:"state,omitempty"`
 	// Edges holds the relations/edges for other nodes in the graph.
 	// The values are being populated by the UserQuery when eager-loading is set.
-	Edges          UserEdges `json:"edges"`
-	parent_id      *int
-	user_spouse_id *int
+	Edges         UserEdges `json:"edges"`
+	user_children *int
+	user_spouse   *int
 }
 
 // UserEdges holds the relations/edges for other nodes in the graph.
@@ -124,8 +124,8 @@ func (*User) scanValues() []interface{} {
 // fkValues returns the types for scanning foreign-keys values from sql.Rows.
 func (*User) fkValues() []interface{} {
 	return []interface{}{
-		&sql.NullInt64{}, // parent_id
-		&sql.NullInt64{}, // user_spouse_id
+		&sql.NullInt64{}, // user_children
+		&sql.NullInt64{}, // user_spouse
 	}
 }
 
@@ -179,16 +179,16 @@ func (u *User) assignValues(values ...interface{}) error {
 	values = values[7:]
 	if len(values) == len(user.ForeignKeys) {
 		if value, ok := values[0].(*sql.NullInt64); !ok {
-			return fmt.Errorf("unexpected type %T for edge-field parent_id", value)
+			return fmt.Errorf("unexpected type %T for edge-field user_children", value)
 		} else if value.Valid {
-			u.parent_id = new(int)
-			*u.parent_id = int(value.Int64)
+			u.user_children = new(int)
+			*u.user_children = int(value.Int64)
 		}
 		if value, ok := values[1].(*sql.NullInt64); !ok {
-			return fmt.Errorf("unexpected type %T for edge-field user_spouse_id", value)
+			return fmt.Errorf("unexpected type %T for edge-field user_spouse", value)
 		} else if value.Valid {
-			u.user_spouse_id = new(int)
-			*u.user_spouse_id = int(value.Int64)
+			u.user_spouse = new(int)
+			*u.user_spouse = int(value.Int64)
 		}
 	}
 	return nil

--- a/entc/integration/migrate/entv1/user/user.go
+++ b/entc/integration/migrate/entv1/user/user.go
@@ -37,22 +37,22 @@ const (
 	// ParentTable is the table the holds the parent relation/edge.
 	ParentTable = "users"
 	// ParentColumn is the table column denoting the parent relation/edge.
-	ParentColumn = "parent_id"
+	ParentColumn = "user_children"
 	// ChildrenTable is the table the holds the children relation/edge.
 	ChildrenTable = "users"
 	// ChildrenColumn is the table column denoting the children relation/edge.
-	ChildrenColumn = "parent_id"
+	ChildrenColumn = "user_children"
 	// SpouseTable is the table the holds the spouse relation/edge.
 	SpouseTable = "users"
 	// SpouseColumn is the table column denoting the spouse relation/edge.
-	SpouseColumn = "user_spouse_id"
+	SpouseColumn = "user_spouse"
 	// CarTable is the table the holds the car relation/edge.
 	CarTable = "cars"
 	// CarInverseTable is the table name for the Car entity.
 	// It exists in this package in order to avoid circular dependency with the "car" package.
 	CarInverseTable = "cars"
 	// CarColumn is the table column denoting the car relation/edge.
-	CarColumn = "owner_id"
+	CarColumn = "user_car"
 )
 
 // Columns holds all SQL columns for user fields.
@@ -69,8 +69,8 @@ var Columns = []string{
 
 // ForeignKeys holds the SQL foreign-keys that are owned by the User type.
 var ForeignKeys = []string{
-	"parent_id",
-	"user_spouse_id",
+	"user_children",
+	"user_spouse",
 }
 
 var (

--- a/entc/integration/migrate/entv1/user_query.go
+++ b/entc/integration/migrate/entv1/user_query.go
@@ -411,7 +411,7 @@ func (uq *UserQuery) sqlAll(ctx context.Context) ([]*User, error) {
 		ids := make([]int, 0, len(nodes))
 		nodeids := make(map[int][]*User)
 		for i := range nodes {
-			if fk := nodes[i].parent_id; fk != nil {
+			if fk := nodes[i].user_children; fk != nil {
 				ids = append(ids, *fk)
 				nodeids[*fk] = append(nodeids[*fk], nodes[i])
 			}
@@ -424,7 +424,7 @@ func (uq *UserQuery) sqlAll(ctx context.Context) ([]*User, error) {
 		for _, n := range neighbors {
 			nodes, ok := nodeids[n.ID]
 			if !ok {
-				return nil, fmt.Errorf(`unexpected foreign-key "parent_id" returned %v`, n.ID)
+				return nil, fmt.Errorf(`unexpected foreign-key "user_children" returned %v`, n.ID)
 			}
 			for i := range nodes {
 				nodes[i].Edges.Parent = n
@@ -448,13 +448,13 @@ func (uq *UserQuery) sqlAll(ctx context.Context) ([]*User, error) {
 			return nil, err
 		}
 		for _, n := range neighbors {
-			fk := n.parent_id
+			fk := n.user_children
 			if fk == nil {
-				return nil, fmt.Errorf(`foreign-key "parent_id" is nil for node %v`, n.ID)
+				return nil, fmt.Errorf(`foreign-key "user_children" is nil for node %v`, n.ID)
 			}
 			node, ok := nodeids[*fk]
 			if !ok {
-				return nil, fmt.Errorf(`unexpected foreign-key "parent_id" returned %v for node %v`, *fk, n.ID)
+				return nil, fmt.Errorf(`unexpected foreign-key "user_children" returned %v for node %v`, *fk, n.ID)
 			}
 			node.Edges.Children = append(node.Edges.Children, n)
 		}
@@ -464,7 +464,7 @@ func (uq *UserQuery) sqlAll(ctx context.Context) ([]*User, error) {
 		ids := make([]int, 0, len(nodes))
 		nodeids := make(map[int][]*User)
 		for i := range nodes {
-			if fk := nodes[i].user_spouse_id; fk != nil {
+			if fk := nodes[i].user_spouse; fk != nil {
 				ids = append(ids, *fk)
 				nodeids[*fk] = append(nodeids[*fk], nodes[i])
 			}
@@ -477,7 +477,7 @@ func (uq *UserQuery) sqlAll(ctx context.Context) ([]*User, error) {
 		for _, n := range neighbors {
 			nodes, ok := nodeids[n.ID]
 			if !ok {
-				return nil, fmt.Errorf(`unexpected foreign-key "user_spouse_id" returned %v`, n.ID)
+				return nil, fmt.Errorf(`unexpected foreign-key "user_spouse" returned %v`, n.ID)
 			}
 			for i := range nodes {
 				nodes[i].Edges.Spouse = n
@@ -501,13 +501,13 @@ func (uq *UserQuery) sqlAll(ctx context.Context) ([]*User, error) {
 			return nil, err
 		}
 		for _, n := range neighbors {
-			fk := n.owner_id
+			fk := n.user_car
 			if fk == nil {
-				return nil, fmt.Errorf(`foreign-key "owner_id" is nil for node %v`, n.ID)
+				return nil, fmt.Errorf(`foreign-key "user_car" is nil for node %v`, n.ID)
 			}
 			node, ok := nodeids[*fk]
 			if !ok {
-				return nil, fmt.Errorf(`unexpected foreign-key "owner_id" returned %v for node %v`, *fk, n.ID)
+				return nil, fmt.Errorf(`unexpected foreign-key "user_car" returned %v for node %v`, *fk, n.ID)
 			}
 			node.Edges.Car = n
 		}

--- a/entc/integration/migrate/entv2/car.go
+++ b/entc/integration/migrate/entv2/car.go
@@ -23,7 +23,7 @@ type Car struct {
 	// Edges holds the relations/edges for other nodes in the graph.
 	// The values are being populated by the CarQuery when eager-loading is set.
 	Edges    CarEdges `json:"edges"`
-	owner_id *int
+	user_car *int
 }
 
 // CarEdges holds the relations/edges for other nodes in the graph.
@@ -59,7 +59,7 @@ func (*Car) scanValues() []interface{} {
 // fkValues returns the types for scanning foreign-keys values from sql.Rows.
 func (*Car) fkValues() []interface{} {
 	return []interface{}{
-		&sql.NullInt64{}, // owner_id
+		&sql.NullInt64{}, // user_car
 	}
 }
 
@@ -78,10 +78,10 @@ func (c *Car) assignValues(values ...interface{}) error {
 	values = values[0:]
 	if len(values) == len(car.ForeignKeys) {
 		if value, ok := values[0].(*sql.NullInt64); !ok {
-			return fmt.Errorf("unexpected type %T for edge-field owner_id", value)
+			return fmt.Errorf("unexpected type %T for edge-field user_car", value)
 		} else if value.Valid {
-			c.owner_id = new(int)
-			*c.owner_id = int(value.Int64)
+			c.user_car = new(int)
+			*c.user_car = int(value.Int64)
 		}
 	}
 	return nil

--- a/entc/integration/migrate/entv2/car/car.go
+++ b/entc/integration/migrate/entv2/car/car.go
@@ -20,7 +20,7 @@ const (
 	// It exists in this package in order to avoid circular dependency with the "user" package.
 	OwnerInverseTable = "users"
 	// OwnerColumn is the table column denoting the owner relation/edge.
-	OwnerColumn = "owner_id"
+	OwnerColumn = "user_car"
 )
 
 // Columns holds all SQL columns for car fields.
@@ -30,5 +30,5 @@ var Columns = []string{
 
 // ForeignKeys holds the SQL foreign-keys that are owned by the Car type.
 var ForeignKeys = []string{
-	"owner_id",
+	"user_car",
 }

--- a/entc/integration/migrate/entv2/car_query.go
+++ b/entc/integration/migrate/entv2/car_query.go
@@ -311,7 +311,7 @@ func (cq *CarQuery) sqlAll(ctx context.Context) ([]*Car, error) {
 		ids := make([]int, 0, len(nodes))
 		nodeids := make(map[int][]*Car)
 		for i := range nodes {
-			if fk := nodes[i].owner_id; fk != nil {
+			if fk := nodes[i].user_car; fk != nil {
 				ids = append(ids, *fk)
 				nodeids[*fk] = append(nodeids[*fk], nodes[i])
 			}
@@ -324,7 +324,7 @@ func (cq *CarQuery) sqlAll(ctx context.Context) ([]*Car, error) {
 		for _, n := range neighbors {
 			nodes, ok := nodeids[n.ID]
 			if !ok {
-				return nil, fmt.Errorf(`unexpected foreign-key "owner_id" returned %v`, n.ID)
+				return nil, fmt.Errorf(`unexpected foreign-key "user_car" returned %v`, n.ID)
 			}
 			for i := range nodes {
 				nodes[i].Edges.Owner = n

--- a/entc/integration/migrate/entv2/client.go
+++ b/entc/integration/migrate/entv2/client.go
@@ -397,3 +397,17 @@ func (c *UserClient) QueryCar(u *User) *CarQuery {
 
 	return query
 }
+
+// QueryPets queries the pets edge of a User.
+func (c *UserClient) QueryPets(u *User) *PetQuery {
+	query := &PetQuery{config: c.config}
+	id := u.ID
+	step := sqlgraph.NewStep(
+		sqlgraph.From(user.Table, user.FieldID, id),
+		sqlgraph.To(pet.Table, pet.FieldID),
+		sqlgraph.Edge(sqlgraph.M2O, false, user.PetsTable, user.PetsColumn),
+	)
+	query.sql = sqlgraph.Neighbors(u.driver.Dialect(), step)
+
+	return query
+}

--- a/entc/integration/migrate/entv2/example_test.go
+++ b/entc/integration/migrate/entv2/example_test.go
@@ -106,6 +106,10 @@ func ExampleUser() {
 		Create().
 		SaveX(ctx)
 	log.Println("car created:", c0)
+	pe1 := client.Pet.
+		Create().
+		SaveX(ctx)
+	log.Println("pet created:", pe1)
 
 	// create user vertex with its edges.
 	u := client.User.
@@ -120,6 +124,7 @@ func ExampleUser() {
 		SetBlob(nil).
 		SetState(user.StateLoggedIn).
 		AddCar(c0).
+		SetPets(pe1).
 		SaveX(ctx)
 	log.Println("user created:", u)
 
@@ -129,6 +134,12 @@ func ExampleUser() {
 		log.Fatalf("failed querying car: %v", err)
 	}
 	log.Println("car found:", c0)
+
+	pe1, err = u.QueryPets().First(ctx)
+	if err != nil {
+		log.Fatalf("failed querying pets: %v", err)
+	}
+	log.Println("pets found:", pe1)
 
 	// Output:
 }

--- a/entc/integration/migrate/entv2/migrate/schema.go
+++ b/entc/integration/migrate/entv2/migrate/schema.go
@@ -17,7 +17,7 @@ var (
 	// CarsColumns holds the columns for the "cars" table.
 	CarsColumns = []*schema.Column{
 		{Name: "id", Type: field.TypeInt, Increment: true},
-		{Name: "owner_id", Type: field.TypeInt, Nullable: true},
+		{Name: "user_car", Type: field.TypeInt, Nullable: true},
 	}
 	// CarsTable holds the schema information for the "cars" table.
 	CarsTable = &schema.Table{
@@ -68,13 +68,22 @@ var (
 		{Name: "renamed", Type: field.TypeString, Nullable: true},
 		{Name: "blob", Type: field.TypeBytes, Nullable: true, Size: 1000},
 		{Name: "state", Type: field.TypeEnum, Nullable: true, Enums: []string{"logged_in", "logged_out", "online"}},
+		{Name: "user_pets", Type: field.TypeInt, Nullable: true},
 	}
 	// UsersTable holds the schema information for the "users" table.
 	UsersTable = &schema.Table{
-		Name:        "users",
-		Columns:     UsersColumns,
-		PrimaryKey:  []*schema.Column{UsersColumns[0]},
-		ForeignKeys: []*schema.ForeignKey{},
+		Name:       "users",
+		Columns:    UsersColumns,
+		PrimaryKey: []*schema.Column{UsersColumns[0]},
+		ForeignKeys: []*schema.ForeignKey{
+			{
+				Symbol:  "users_pets_pets",
+				Columns: []*schema.Column{UsersColumns[10]},
+
+				RefColumns: []*schema.Column{PetsColumns[0]},
+				OnDelete:   schema.SetNull,
+			},
+		},
 		Indexes: []*schema.Index{
 			{
 				Name:    "user_phone_age",
@@ -94,4 +103,5 @@ var (
 
 func init() {
 	CarsTable.ForeignKeys[0].RefTable = UsersTable
+	UsersTable.ForeignKeys[0].RefTable = PetsTable
 }

--- a/entc/integration/migrate/entv2/schema/user.go
+++ b/entc/integration/migrate/entv2/schema/user.go
@@ -57,6 +57,9 @@ func (User) Edges() []ent.Edge {
 		// Edge(children<-M2O->parent) to be dropped.
 		// Edge(spouse<-O2O->spouse) to be dropped.
 		edge.To("car", Car.Type),
+		// A new edge was added.
+		edge.To("pets", Pet.Type).
+			Unique(),
 	}
 }
 

--- a/entc/integration/migrate/entv2/user/user.go
+++ b/entc/integration/migrate/entv2/user/user.go
@@ -44,7 +44,14 @@ const (
 	// It exists in this package in order to avoid circular dependency with the "car" package.
 	CarInverseTable = "cars"
 	// CarColumn is the table column denoting the car relation/edge.
-	CarColumn = "owner_id"
+	CarColumn = "user_car"
+	// PetsTable is the table the holds the pets relation/edge.
+	PetsTable = "users"
+	// PetsInverseTable is the table name for the Pet entity.
+	// It exists in this package in order to avoid circular dependency with the "pet" package.
+	PetsInverseTable = "pets"
+	// PetsColumn is the table column denoting the pets relation/edge.
+	PetsColumn = "user_pets"
 )
 
 // Columns holds all SQL columns for user fields.
@@ -59,6 +66,11 @@ var Columns = []string{
 	FieldNewName,
 	FieldBlob,
 	FieldState,
+}
+
+// ForeignKeys holds the SQL foreign-keys that are owned by the User type.
+var ForeignKeys = []string{
+	"user_pets",
 }
 
 var (

--- a/entc/integration/migrate/entv2/user/where.go
+++ b/entc/integration/migrate/entv2/user/where.go
@@ -1187,6 +1187,36 @@ func HasCarWith(preds ...predicate.Car) predicate.User {
 	)
 }
 
+// HasPets applies the HasEdge predicate on the "pets" edge.
+func HasPets() predicate.User {
+	return predicate.User(func(s *sql.Selector) {
+		step := sqlgraph.NewStep(
+			sqlgraph.From(Table, FieldID),
+			sqlgraph.To(PetsTable, FieldID),
+			sqlgraph.Edge(sqlgraph.M2O, false, PetsTable, PetsColumn),
+		)
+		sqlgraph.HasNeighbors(s, step)
+	},
+	)
+}
+
+// HasPetsWith applies the HasEdge predicate on the "pets" edge with a given conditions (other predicates).
+func HasPetsWith(preds ...predicate.Pet) predicate.User {
+	return predicate.User(func(s *sql.Selector) {
+		step := sqlgraph.NewStep(
+			sqlgraph.From(Table, FieldID),
+			sqlgraph.To(PetsInverseTable, FieldID),
+			sqlgraph.Edge(sqlgraph.M2O, false, PetsTable, PetsColumn),
+		)
+		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
+			for _, p := range preds {
+				p(s)
+			}
+		})
+	},
+	)
+}
+
 // And groups list of predicates with the AND operator between them.
 func And(predicates ...predicate.User) predicate.User {
 	return predicate.User(

--- a/entc/integration/template/ent/migrate/schema.go
+++ b/entc/integration/template/ent/migrate/schema.go
@@ -29,7 +29,7 @@ var (
 		{Name: "id", Type: field.TypeInt, Increment: true},
 		{Name: "age", Type: field.TypeInt},
 		{Name: "licensed_at", Type: field.TypeTime, Nullable: true},
-		{Name: "owner_id", Type: field.TypeInt, Nullable: true},
+		{Name: "user_pets", Type: field.TypeInt, Nullable: true},
 	}
 	// PetsTable holds the schema information for the "pets" table.
 	PetsTable = &schema.Table{

--- a/entc/integration/template/ent/pet.go
+++ b/entc/integration/template/ent/pet.go
@@ -27,8 +27,8 @@ type Pet struct {
 	LicensedAt *time.Time `json:"licensed_at,omitempty"`
 	// Edges holds the relations/edges for other nodes in the graph.
 	// The values are being populated by the PetQuery when eager-loading is set.
-	Edges    PetEdges `json:"edges"`
-	owner_id *int
+	Edges     PetEdges `json:"edges"`
+	user_pets *int
 }
 
 // PetEdges holds the relations/edges for other nodes in the graph.
@@ -66,7 +66,7 @@ func (*Pet) scanValues() []interface{} {
 // fkValues returns the types for scanning foreign-keys values from sql.Rows.
 func (*Pet) fkValues() []interface{} {
 	return []interface{}{
-		&sql.NullInt64{}, // owner_id
+		&sql.NullInt64{}, // user_pets
 	}
 }
 
@@ -96,10 +96,10 @@ func (pe *Pet) assignValues(values ...interface{}) error {
 	values = values[2:]
 	if len(values) == len(pet.ForeignKeys) {
 		if value, ok := values[0].(*sql.NullInt64); !ok {
-			return fmt.Errorf("unexpected type %T for edge-field owner_id", value)
+			return fmt.Errorf("unexpected type %T for edge-field user_pets", value)
 		} else if value.Valid {
-			pe.owner_id = new(int)
-			*pe.owner_id = int(value.Int64)
+			pe.user_pets = new(int)
+			*pe.user_pets = int(value.Int64)
 		}
 	}
 	return nil

--- a/entc/integration/template/ent/pet/pet.go
+++ b/entc/integration/template/ent/pet/pet.go
@@ -24,7 +24,7 @@ const (
 	// It exists in this package in order to avoid circular dependency with the "user" package.
 	OwnerInverseTable = "users"
 	// OwnerColumn is the table column denoting the owner relation/edge.
-	OwnerColumn = "owner_id"
+	OwnerColumn = "user_pets"
 )
 
 // Columns holds all SQL columns for pet fields.
@@ -36,5 +36,5 @@ var Columns = []string{
 
 // ForeignKeys holds the SQL foreign-keys that are owned by the Pet type.
 var ForeignKeys = []string{
-	"owner_id",
+	"user_pets",
 }

--- a/entc/integration/template/ent/pet_query.go
+++ b/entc/integration/template/ent/pet_query.go
@@ -335,7 +335,7 @@ func (pq *PetQuery) sqlAll(ctx context.Context) ([]*Pet, error) {
 		ids := make([]int, 0, len(nodes))
 		nodeids := make(map[int][]*Pet)
 		for i := range nodes {
-			if fk := nodes[i].owner_id; fk != nil {
+			if fk := nodes[i].user_pets; fk != nil {
 				ids = append(ids, *fk)
 				nodeids[*fk] = append(nodeids[*fk], nodes[i])
 			}
@@ -348,7 +348,7 @@ func (pq *PetQuery) sqlAll(ctx context.Context) ([]*Pet, error) {
 		for _, n := range neighbors {
 			nodes, ok := nodeids[n.ID]
 			if !ok {
-				return nil, fmt.Errorf(`unexpected foreign-key "owner_id" returned %v`, n.ID)
+				return nil, fmt.Errorf(`unexpected foreign-key "user_pets" returned %v`, n.ID)
 			}
 			for i := range nodes {
 				nodes[i].Edges.Owner = n

--- a/entc/integration/template/ent/user/user.go
+++ b/entc/integration/template/ent/user/user.go
@@ -22,7 +22,7 @@ const (
 	// It exists in this package in order to avoid circular dependency with the "pet" package.
 	PetsInverseTable = "pets"
 	// PetsColumn is the table column denoting the pets relation/edge.
-	PetsColumn = "owner_id"
+	PetsColumn = "user_pets"
 	// FriendsTable is the table the holds the friends relation/edge. The primary key declared below.
 	FriendsTable = "user_friends"
 )

--- a/entc/integration/template/ent/user_query.go
+++ b/entc/integration/template/ent/user_query.go
@@ -362,13 +362,13 @@ func (uq *UserQuery) sqlAll(ctx context.Context) ([]*User, error) {
 			return nil, err
 		}
 		for _, n := range neighbors {
-			fk := n.owner_id
+			fk := n.user_pets
 			if fk == nil {
-				return nil, fmt.Errorf(`foreign-key "owner_id" is nil for node %v`, n.ID)
+				return nil, fmt.Errorf(`foreign-key "user_pets" is nil for node %v`, n.ID)
 			}
 			node, ok := nodeids[*fk]
 			if !ok {
-				return nil, fmt.Errorf(`unexpected foreign-key "owner_id" returned %v for node %v`, *fk, n.ID)
+				return nil, fmt.Errorf(`unexpected foreign-key "user_pets" returned %v for node %v`, *fk, n.ID)
 			}
 			node.Edges.Pets = append(node.Edges.Pets, n)
 		}

--- a/examples/edgeindex/ent/city/city.go
+++ b/examples/edgeindex/ent/city/city.go
@@ -22,7 +22,7 @@ const (
 	// It exists in this package in order to avoid circular dependency with the "street" package.
 	StreetsInverseTable = "streets"
 	// StreetsColumn is the table column denoting the streets relation/edge.
-	StreetsColumn = "city_id"
+	StreetsColumn = "city_streets"
 )
 
 // Columns holds all SQL columns for city fields.

--- a/examples/edgeindex/ent/city_query.go
+++ b/examples/edgeindex/ent/city_query.go
@@ -337,13 +337,13 @@ func (cq *CityQuery) sqlAll(ctx context.Context) ([]*City, error) {
 			return nil, err
 		}
 		for _, n := range neighbors {
-			fk := n.city_id
+			fk := n.city_streets
 			if fk == nil {
-				return nil, fmt.Errorf(`foreign-key "city_id" is nil for node %v`, n.ID)
+				return nil, fmt.Errorf(`foreign-key "city_streets" is nil for node %v`, n.ID)
 			}
 			node, ok := nodeids[*fk]
 			if !ok {
-				return nil, fmt.Errorf(`unexpected foreign-key "city_id" returned %v for node %v`, *fk, n.ID)
+				return nil, fmt.Errorf(`unexpected foreign-key "city_streets" returned %v for node %v`, *fk, n.ID)
 			}
 			node.Edges.Streets = append(node.Edges.Streets, n)
 		}

--- a/examples/edgeindex/ent/migrate/schema.go
+++ b/examples/edgeindex/ent/migrate/schema.go
@@ -28,7 +28,7 @@ var (
 	StreetsColumns = []*schema.Column{
 		{Name: "id", Type: field.TypeInt, Increment: true},
 		{Name: "name", Type: field.TypeString},
-		{Name: "city_id", Type: field.TypeInt, Nullable: true},
+		{Name: "city_streets", Type: field.TypeInt, Nullable: true},
 	}
 	// StreetsTable holds the schema information for the "streets" table.
 	StreetsTable = &schema.Table{
@@ -46,7 +46,7 @@ var (
 		},
 		Indexes: []*schema.Index{
 			{
-				Name:    "street_name_city_id",
+				Name:    "street_name_city_streets",
 				Unique:  true,
 				Columns: []*schema.Column{StreetsColumns[1], StreetsColumns[2]},
 			},

--- a/examples/edgeindex/ent/street.go
+++ b/examples/edgeindex/ent/street.go
@@ -24,8 +24,8 @@ type Street struct {
 	Name string `json:"name,omitempty"`
 	// Edges holds the relations/edges for other nodes in the graph.
 	// The values are being populated by the StreetQuery when eager-loading is set.
-	Edges   StreetEdges `json:"edges"`
-	city_id *int
+	Edges        StreetEdges `json:"edges"`
+	city_streets *int
 }
 
 // StreetEdges holds the relations/edges for other nodes in the graph.
@@ -62,7 +62,7 @@ func (*Street) scanValues() []interface{} {
 // fkValues returns the types for scanning foreign-keys values from sql.Rows.
 func (*Street) fkValues() []interface{} {
 	return []interface{}{
-		&sql.NullInt64{}, // city_id
+		&sql.NullInt64{}, // city_streets
 	}
 }
 
@@ -86,10 +86,10 @@ func (s *Street) assignValues(values ...interface{}) error {
 	values = values[1:]
 	if len(values) == len(street.ForeignKeys) {
 		if value, ok := values[0].(*sql.NullInt64); !ok {
-			return fmt.Errorf("unexpected type %T for edge-field city_id", value)
+			return fmt.Errorf("unexpected type %T for edge-field city_streets", value)
 		} else if value.Valid {
-			s.city_id = new(int)
-			*s.city_id = int(value.Int64)
+			s.city_streets = new(int)
+			*s.city_streets = int(value.Int64)
 		}
 	}
 	return nil

--- a/examples/edgeindex/ent/street/street.go
+++ b/examples/edgeindex/ent/street/street.go
@@ -22,7 +22,7 @@ const (
 	// It exists in this package in order to avoid circular dependency with the "city" package.
 	CityInverseTable = "cities"
 	// CityColumn is the table column denoting the city relation/edge.
-	CityColumn = "city_id"
+	CityColumn = "city_streets"
 )
 
 // Columns holds all SQL columns for street fields.
@@ -33,5 +33,5 @@ var Columns = []string{
 
 // ForeignKeys holds the SQL foreign-keys that are owned by the Street type.
 var ForeignKeys = []string{
-	"city_id",
+	"city_streets",
 }

--- a/examples/edgeindex/ent/street_query.go
+++ b/examples/edgeindex/ent/street_query.go
@@ -335,7 +335,7 @@ func (sq *StreetQuery) sqlAll(ctx context.Context) ([]*Street, error) {
 		ids := make([]int, 0, len(nodes))
 		nodeids := make(map[int][]*Street)
 		for i := range nodes {
-			if fk := nodes[i].city_id; fk != nil {
+			if fk := nodes[i].city_streets; fk != nil {
 				ids = append(ids, *fk)
 				nodeids[*fk] = append(nodeids[*fk], nodes[i])
 			}
@@ -348,7 +348,7 @@ func (sq *StreetQuery) sqlAll(ctx context.Context) ([]*Street, error) {
 		for _, n := range neighbors {
 			nodes, ok := nodeids[n.ID]
 			if !ok {
-				return nil, fmt.Errorf(`unexpected foreign-key "city_id" returned %v`, n.ID)
+				return nil, fmt.Errorf(`unexpected foreign-key "city_streets" returned %v`, n.ID)
 			}
 			for i := range nodes {
 				nodes[i].Edges.City = n

--- a/examples/o2m2types/ent/migrate/schema.go
+++ b/examples/o2m2types/ent/migrate/schema.go
@@ -16,7 +16,7 @@ var (
 	PetsColumns = []*schema.Column{
 		{Name: "id", Type: field.TypeInt, Increment: true},
 		{Name: "name", Type: field.TypeString},
-		{Name: "owner_id", Type: field.TypeInt, Nullable: true},
+		{Name: "user_pets", Type: field.TypeInt, Nullable: true},
 	}
 	// PetsTable holds the schema information for the "pets" table.
 	PetsTable = &schema.Table{

--- a/examples/o2m2types/ent/pet.go
+++ b/examples/o2m2types/ent/pet.go
@@ -24,8 +24,8 @@ type Pet struct {
 	Name string `json:"name,omitempty"`
 	// Edges holds the relations/edges for other nodes in the graph.
 	// The values are being populated by the PetQuery when eager-loading is set.
-	Edges    PetEdges `json:"edges"`
-	owner_id *int
+	Edges     PetEdges `json:"edges"`
+	user_pets *int
 }
 
 // PetEdges holds the relations/edges for other nodes in the graph.
@@ -62,7 +62,7 @@ func (*Pet) scanValues() []interface{} {
 // fkValues returns the types for scanning foreign-keys values from sql.Rows.
 func (*Pet) fkValues() []interface{} {
 	return []interface{}{
-		&sql.NullInt64{}, // owner_id
+		&sql.NullInt64{}, // user_pets
 	}
 }
 
@@ -86,10 +86,10 @@ func (pe *Pet) assignValues(values ...interface{}) error {
 	values = values[1:]
 	if len(values) == len(pet.ForeignKeys) {
 		if value, ok := values[0].(*sql.NullInt64); !ok {
-			return fmt.Errorf("unexpected type %T for edge-field owner_id", value)
+			return fmt.Errorf("unexpected type %T for edge-field user_pets", value)
 		} else if value.Valid {
-			pe.owner_id = new(int)
-			*pe.owner_id = int(value.Int64)
+			pe.user_pets = new(int)
+			*pe.user_pets = int(value.Int64)
 		}
 	}
 	return nil

--- a/examples/o2m2types/ent/pet/pet.go
+++ b/examples/o2m2types/ent/pet/pet.go
@@ -22,7 +22,7 @@ const (
 	// It exists in this package in order to avoid circular dependency with the "user" package.
 	OwnerInverseTable = "users"
 	// OwnerColumn is the table column denoting the owner relation/edge.
-	OwnerColumn = "owner_id"
+	OwnerColumn = "user_pets"
 )
 
 // Columns holds all SQL columns for pet fields.
@@ -33,5 +33,5 @@ var Columns = []string{
 
 // ForeignKeys holds the SQL foreign-keys that are owned by the Pet type.
 var ForeignKeys = []string{
-	"owner_id",
+	"user_pets",
 }

--- a/examples/o2m2types/ent/pet_query.go
+++ b/examples/o2m2types/ent/pet_query.go
@@ -335,7 +335,7 @@ func (pq *PetQuery) sqlAll(ctx context.Context) ([]*Pet, error) {
 		ids := make([]int, 0, len(nodes))
 		nodeids := make(map[int][]*Pet)
 		for i := range nodes {
-			if fk := nodes[i].owner_id; fk != nil {
+			if fk := nodes[i].user_pets; fk != nil {
 				ids = append(ids, *fk)
 				nodeids[*fk] = append(nodeids[*fk], nodes[i])
 			}
@@ -348,7 +348,7 @@ func (pq *PetQuery) sqlAll(ctx context.Context) ([]*Pet, error) {
 		for _, n := range neighbors {
 			nodes, ok := nodeids[n.ID]
 			if !ok {
-				return nil, fmt.Errorf(`unexpected foreign-key "owner_id" returned %v`, n.ID)
+				return nil, fmt.Errorf(`unexpected foreign-key "user_pets" returned %v`, n.ID)
 			}
 			for i := range nodes {
 				nodes[i].Edges.Owner = n

--- a/examples/o2m2types/ent/user/user.go
+++ b/examples/o2m2types/ent/user/user.go
@@ -24,7 +24,7 @@ const (
 	// It exists in this package in order to avoid circular dependency with the "pet" package.
 	PetsInverseTable = "pets"
 	// PetsColumn is the table column denoting the pets relation/edge.
-	PetsColumn = "owner_id"
+	PetsColumn = "user_pets"
 )
 
 // Columns holds all SQL columns for user fields.

--- a/examples/o2m2types/ent/user_query.go
+++ b/examples/o2m2types/ent/user_query.go
@@ -337,13 +337,13 @@ func (uq *UserQuery) sqlAll(ctx context.Context) ([]*User, error) {
 			return nil, err
 		}
 		for _, n := range neighbors {
-			fk := n.owner_id
+			fk := n.user_pets
 			if fk == nil {
-				return nil, fmt.Errorf(`foreign-key "owner_id" is nil for node %v`, n.ID)
+				return nil, fmt.Errorf(`foreign-key "user_pets" is nil for node %v`, n.ID)
 			}
 			node, ok := nodeids[*fk]
 			if !ok {
-				return nil, fmt.Errorf(`unexpected foreign-key "owner_id" returned %v for node %v`, *fk, n.ID)
+				return nil, fmt.Errorf(`unexpected foreign-key "user_pets" returned %v for node %v`, *fk, n.ID)
 			}
 			node.Edges.Pets = append(node.Edges.Pets, n)
 		}

--- a/examples/o2mrecur/ent/migrate/schema.go
+++ b/examples/o2mrecur/ent/migrate/schema.go
@@ -16,7 +16,7 @@ var (
 	NodesColumns = []*schema.Column{
 		{Name: "id", Type: field.TypeInt, Increment: true},
 		{Name: "value", Type: field.TypeInt},
-		{Name: "parent_id", Type: field.TypeInt, Nullable: true},
+		{Name: "node_children", Type: field.TypeInt, Nullable: true},
 	}
 	// NodesTable holds the schema information for the "nodes" table.
 	NodesTable = &schema.Table{

--- a/examples/o2mrecur/ent/node.go
+++ b/examples/o2mrecur/ent/node.go
@@ -23,8 +23,8 @@ type Node struct {
 	Value int `json:"value,omitempty"`
 	// Edges holds the relations/edges for other nodes in the graph.
 	// The values are being populated by the NodeQuery when eager-loading is set.
-	Edges     NodeEdges `json:"edges"`
-	parent_id *int
+	Edges         NodeEdges `json:"edges"`
+	node_children *int
 }
 
 // NodeEdges holds the relations/edges for other nodes in the graph.
@@ -72,7 +72,7 @@ func (*Node) scanValues() []interface{} {
 // fkValues returns the types for scanning foreign-keys values from sql.Rows.
 func (*Node) fkValues() []interface{} {
 	return []interface{}{
-		&sql.NullInt64{}, // parent_id
+		&sql.NullInt64{}, // node_children
 	}
 }
 
@@ -96,10 +96,10 @@ func (n *Node) assignValues(values ...interface{}) error {
 	values = values[1:]
 	if len(values) == len(node.ForeignKeys) {
 		if value, ok := values[0].(*sql.NullInt64); !ok {
-			return fmt.Errorf("unexpected type %T for edge-field parent_id", value)
+			return fmt.Errorf("unexpected type %T for edge-field node_children", value)
 		} else if value.Valid {
-			n.parent_id = new(int)
-			*n.parent_id = int(value.Int64)
+			n.node_children = new(int)
+			*n.node_children = int(value.Int64)
 		}
 	}
 	return nil

--- a/examples/o2mrecur/ent/node/node.go
+++ b/examples/o2mrecur/ent/node/node.go
@@ -19,11 +19,11 @@ const (
 	// ParentTable is the table the holds the parent relation/edge.
 	ParentTable = "nodes"
 	// ParentColumn is the table column denoting the parent relation/edge.
-	ParentColumn = "parent_id"
+	ParentColumn = "node_children"
 	// ChildrenTable is the table the holds the children relation/edge.
 	ChildrenTable = "nodes"
 	// ChildrenColumn is the table column denoting the children relation/edge.
-	ChildrenColumn = "parent_id"
+	ChildrenColumn = "node_children"
 )
 
 // Columns holds all SQL columns for node fields.
@@ -34,5 +34,5 @@ var Columns = []string{
 
 // ForeignKeys holds the SQL foreign-keys that are owned by the Node type.
 var ForeignKeys = []string{
-	"parent_id",
+	"node_children",
 }

--- a/examples/o2mrecur/ent/node_query.go
+++ b/examples/o2mrecur/ent/node_query.go
@@ -360,7 +360,7 @@ func (nq *NodeQuery) sqlAll(ctx context.Context) ([]*Node, error) {
 		ids := make([]int, 0, len(nodes))
 		nodeids := make(map[int][]*Node)
 		for i := range nodes {
-			if fk := nodes[i].parent_id; fk != nil {
+			if fk := nodes[i].node_children; fk != nil {
 				ids = append(ids, *fk)
 				nodeids[*fk] = append(nodeids[*fk], nodes[i])
 			}
@@ -373,7 +373,7 @@ func (nq *NodeQuery) sqlAll(ctx context.Context) ([]*Node, error) {
 		for _, n := range neighbors {
 			nodes, ok := nodeids[n.ID]
 			if !ok {
-				return nil, fmt.Errorf(`unexpected foreign-key "parent_id" returned %v`, n.ID)
+				return nil, fmt.Errorf(`unexpected foreign-key "node_children" returned %v`, n.ID)
 			}
 			for i := range nodes {
 				nodes[i].Edges.Parent = n
@@ -397,13 +397,13 @@ func (nq *NodeQuery) sqlAll(ctx context.Context) ([]*Node, error) {
 			return nil, err
 		}
 		for _, n := range neighbors {
-			fk := n.parent_id
+			fk := n.node_children
 			if fk == nil {
-				return nil, fmt.Errorf(`foreign-key "parent_id" is nil for node %v`, n.ID)
+				return nil, fmt.Errorf(`foreign-key "node_children" is nil for node %v`, n.ID)
 			}
 			node, ok := nodeids[*fk]
 			if !ok {
-				return nil, fmt.Errorf(`unexpected foreign-key "parent_id" returned %v for node %v`, *fk, n.ID)
+				return nil, fmt.Errorf(`unexpected foreign-key "node_children" returned %v for node %v`, *fk, n.ID)
 			}
 			node.Edges.Children = append(node.Edges.Children, n)
 		}

--- a/examples/o2o2types/ent/card.go
+++ b/examples/o2o2types/ent/card.go
@@ -27,8 +27,8 @@ type Card struct {
 	Number string `json:"number,omitempty"`
 	// Edges holds the relations/edges for other nodes in the graph.
 	// The values are being populated by the CardQuery when eager-loading is set.
-	Edges    CardEdges `json:"edges"`
-	owner_id *int
+	Edges     CardEdges `json:"edges"`
+	user_card *int
 }
 
 // CardEdges holds the relations/edges for other nodes in the graph.
@@ -66,7 +66,7 @@ func (*Card) scanValues() []interface{} {
 // fkValues returns the types for scanning foreign-keys values from sql.Rows.
 func (*Card) fkValues() []interface{} {
 	return []interface{}{
-		&sql.NullInt64{}, // owner_id
+		&sql.NullInt64{}, // user_card
 	}
 }
 
@@ -95,10 +95,10 @@ func (c *Card) assignValues(values ...interface{}) error {
 	values = values[2:]
 	if len(values) == len(card.ForeignKeys) {
 		if value, ok := values[0].(*sql.NullInt64); !ok {
-			return fmt.Errorf("unexpected type %T for edge-field owner_id", value)
+			return fmt.Errorf("unexpected type %T for edge-field user_card", value)
 		} else if value.Valid {
-			c.owner_id = new(int)
-			*c.owner_id = int(value.Int64)
+			c.user_card = new(int)
+			*c.user_card = int(value.Int64)
 		}
 	}
 	return nil

--- a/examples/o2o2types/ent/card/card.go
+++ b/examples/o2o2types/ent/card/card.go
@@ -24,7 +24,7 @@ const (
 	// It exists in this package in order to avoid circular dependency with the "user" package.
 	OwnerInverseTable = "users"
 	// OwnerColumn is the table column denoting the owner relation/edge.
-	OwnerColumn = "owner_id"
+	OwnerColumn = "user_card"
 )
 
 // Columns holds all SQL columns for card fields.
@@ -36,5 +36,5 @@ var Columns = []string{
 
 // ForeignKeys holds the SQL foreign-keys that are owned by the Card type.
 var ForeignKeys = []string{
-	"owner_id",
+	"user_card",
 }

--- a/examples/o2o2types/ent/card_query.go
+++ b/examples/o2o2types/ent/card_query.go
@@ -335,7 +335,7 @@ func (cq *CardQuery) sqlAll(ctx context.Context) ([]*Card, error) {
 		ids := make([]int, 0, len(nodes))
 		nodeids := make(map[int][]*Card)
 		for i := range nodes {
-			if fk := nodes[i].owner_id; fk != nil {
+			if fk := nodes[i].user_card; fk != nil {
 				ids = append(ids, *fk)
 				nodeids[*fk] = append(nodeids[*fk], nodes[i])
 			}
@@ -348,7 +348,7 @@ func (cq *CardQuery) sqlAll(ctx context.Context) ([]*Card, error) {
 		for _, n := range neighbors {
 			nodes, ok := nodeids[n.ID]
 			if !ok {
-				return nil, fmt.Errorf(`unexpected foreign-key "owner_id" returned %v`, n.ID)
+				return nil, fmt.Errorf(`unexpected foreign-key "user_card" returned %v`, n.ID)
 			}
 			for i := range nodes {
 				nodes[i].Edges.Owner = n

--- a/examples/o2o2types/ent/migrate/schema.go
+++ b/examples/o2o2types/ent/migrate/schema.go
@@ -17,7 +17,7 @@ var (
 		{Name: "id", Type: field.TypeInt, Increment: true},
 		{Name: "expired", Type: field.TypeTime},
 		{Name: "number", Type: field.TypeString},
-		{Name: "owner_id", Type: field.TypeInt, Unique: true, Nullable: true},
+		{Name: "user_card", Type: field.TypeInt, Unique: true, Nullable: true},
 	}
 	// CardsTable holds the schema information for the "cards" table.
 	CardsTable = &schema.Table{

--- a/examples/o2o2types/ent/user/user.go
+++ b/examples/o2o2types/ent/user/user.go
@@ -24,7 +24,7 @@ const (
 	// It exists in this package in order to avoid circular dependency with the "card" package.
 	CardInverseTable = "cards"
 	// CardColumn is the table column denoting the card relation/edge.
-	CardColumn = "owner_id"
+	CardColumn = "user_card"
 )
 
 // Columns holds all SQL columns for user fields.

--- a/examples/o2o2types/ent/user_query.go
+++ b/examples/o2o2types/ent/user_query.go
@@ -337,13 +337,13 @@ func (uq *UserQuery) sqlAll(ctx context.Context) ([]*User, error) {
 			return nil, err
 		}
 		for _, n := range neighbors {
-			fk := n.owner_id
+			fk := n.user_card
 			if fk == nil {
-				return nil, fmt.Errorf(`foreign-key "owner_id" is nil for node %v`, n.ID)
+				return nil, fmt.Errorf(`foreign-key "user_card" is nil for node %v`, n.ID)
 			}
 			node, ok := nodeids[*fk]
 			if !ok {
-				return nil, fmt.Errorf(`unexpected foreign-key "owner_id" returned %v for node %v`, *fk, n.ID)
+				return nil, fmt.Errorf(`unexpected foreign-key "user_card" returned %v for node %v`, *fk, n.ID)
 			}
 			node.Edges.Card = n
 		}

--- a/examples/o2obidi/ent/migrate/schema.go
+++ b/examples/o2obidi/ent/migrate/schema.go
@@ -17,7 +17,7 @@ var (
 		{Name: "id", Type: field.TypeInt, Increment: true},
 		{Name: "age", Type: field.TypeInt},
 		{Name: "name", Type: field.TypeString},
-		{Name: "user_spouse_id", Type: field.TypeInt, Unique: true, Nullable: true},
+		{Name: "user_spouse", Type: field.TypeInt, Unique: true, Nullable: true},
 	}
 	// UsersTable holds the schema information for the "users" table.
 	UsersTable = &schema.Table{

--- a/examples/o2obidi/ent/user.go
+++ b/examples/o2obidi/ent/user.go
@@ -25,8 +25,8 @@ type User struct {
 	Name string `json:"name,omitempty"`
 	// Edges holds the relations/edges for other nodes in the graph.
 	// The values are being populated by the UserQuery when eager-loading is set.
-	Edges          UserEdges `json:"edges"`
-	user_spouse_id *int
+	Edges       UserEdges `json:"edges"`
+	user_spouse *int
 }
 
 // UserEdges holds the relations/edges for other nodes in the graph.
@@ -64,7 +64,7 @@ func (*User) scanValues() []interface{} {
 // fkValues returns the types for scanning foreign-keys values from sql.Rows.
 func (*User) fkValues() []interface{} {
 	return []interface{}{
-		&sql.NullInt64{}, // user_spouse_id
+		&sql.NullInt64{}, // user_spouse
 	}
 }
 
@@ -93,10 +93,10 @@ func (u *User) assignValues(values ...interface{}) error {
 	values = values[2:]
 	if len(values) == len(user.ForeignKeys) {
 		if value, ok := values[0].(*sql.NullInt64); !ok {
-			return fmt.Errorf("unexpected type %T for edge-field user_spouse_id", value)
+			return fmt.Errorf("unexpected type %T for edge-field user_spouse", value)
 		} else if value.Valid {
-			u.user_spouse_id = new(int)
-			*u.user_spouse_id = int(value.Int64)
+			u.user_spouse = new(int)
+			*u.user_spouse = int(value.Int64)
 		}
 	}
 	return nil

--- a/examples/o2obidi/ent/user/user.go
+++ b/examples/o2obidi/ent/user/user.go
@@ -21,7 +21,7 @@ const (
 	// SpouseTable is the table the holds the spouse relation/edge.
 	SpouseTable = "users"
 	// SpouseColumn is the table column denoting the spouse relation/edge.
-	SpouseColumn = "user_spouse_id"
+	SpouseColumn = "user_spouse"
 )
 
 // Columns holds all SQL columns for user fields.
@@ -33,5 +33,5 @@ var Columns = []string{
 
 // ForeignKeys holds the SQL foreign-keys that are owned by the User type.
 var ForeignKeys = []string{
-	"user_spouse_id",
+	"user_spouse",
 }

--- a/examples/o2obidi/ent/user_query.go
+++ b/examples/o2obidi/ent/user_query.go
@@ -334,7 +334,7 @@ func (uq *UserQuery) sqlAll(ctx context.Context) ([]*User, error) {
 		ids := make([]int, 0, len(nodes))
 		nodeids := make(map[int][]*User)
 		for i := range nodes {
-			if fk := nodes[i].user_spouse_id; fk != nil {
+			if fk := nodes[i].user_spouse; fk != nil {
 				ids = append(ids, *fk)
 				nodeids[*fk] = append(nodeids[*fk], nodes[i])
 			}
@@ -347,7 +347,7 @@ func (uq *UserQuery) sqlAll(ctx context.Context) ([]*User, error) {
 		for _, n := range neighbors {
 			nodes, ok := nodeids[n.ID]
 			if !ok {
-				return nil, fmt.Errorf(`unexpected foreign-key "user_spouse_id" returned %v`, n.ID)
+				return nil, fmt.Errorf(`unexpected foreign-key "user_spouse" returned %v`, n.ID)
 			}
 			for i := range nodes {
 				nodes[i].Edges.Spouse = n

--- a/examples/o2orecur/ent/migrate/schema.go
+++ b/examples/o2orecur/ent/migrate/schema.go
@@ -16,7 +16,7 @@ var (
 	NodesColumns = []*schema.Column{
 		{Name: "id", Type: field.TypeInt, Increment: true},
 		{Name: "value", Type: field.TypeInt},
-		{Name: "prev_id", Type: field.TypeInt, Unique: true, Nullable: true},
+		{Name: "node_next", Type: field.TypeInt, Unique: true, Nullable: true},
 	}
 	// NodesTable holds the schema information for the "nodes" table.
 	NodesTable = &schema.Table{

--- a/examples/o2orecur/ent/node.go
+++ b/examples/o2orecur/ent/node.go
@@ -23,8 +23,8 @@ type Node struct {
 	Value int `json:"value,omitempty"`
 	// Edges holds the relations/edges for other nodes in the graph.
 	// The values are being populated by the NodeQuery when eager-loading is set.
-	Edges   NodeEdges `json:"edges"`
-	prev_id *int
+	Edges     NodeEdges `json:"edges"`
+	node_next *int
 }
 
 // NodeEdges holds the relations/edges for other nodes in the graph.
@@ -77,7 +77,7 @@ func (*Node) scanValues() []interface{} {
 // fkValues returns the types for scanning foreign-keys values from sql.Rows.
 func (*Node) fkValues() []interface{} {
 	return []interface{}{
-		&sql.NullInt64{}, // prev_id
+		&sql.NullInt64{}, // node_next
 	}
 }
 
@@ -101,10 +101,10 @@ func (n *Node) assignValues(values ...interface{}) error {
 	values = values[1:]
 	if len(values) == len(node.ForeignKeys) {
 		if value, ok := values[0].(*sql.NullInt64); !ok {
-			return fmt.Errorf("unexpected type %T for edge-field prev_id", value)
+			return fmt.Errorf("unexpected type %T for edge-field node_next", value)
 		} else if value.Valid {
-			n.prev_id = new(int)
-			*n.prev_id = int(value.Int64)
+			n.node_next = new(int)
+			*n.node_next = int(value.Int64)
 		}
 	}
 	return nil

--- a/examples/o2orecur/ent/node/node.go
+++ b/examples/o2orecur/ent/node/node.go
@@ -19,11 +19,11 @@ const (
 	// PrevTable is the table the holds the prev relation/edge.
 	PrevTable = "nodes"
 	// PrevColumn is the table column denoting the prev relation/edge.
-	PrevColumn = "prev_id"
+	PrevColumn = "node_next"
 	// NextTable is the table the holds the next relation/edge.
 	NextTable = "nodes"
 	// NextColumn is the table column denoting the next relation/edge.
-	NextColumn = "prev_id"
+	NextColumn = "node_next"
 )
 
 // Columns holds all SQL columns for node fields.
@@ -34,5 +34,5 @@ var Columns = []string{
 
 // ForeignKeys holds the SQL foreign-keys that are owned by the Node type.
 var ForeignKeys = []string{
-	"prev_id",
+	"node_next",
 }

--- a/examples/o2orecur/ent/node_query.go
+++ b/examples/o2orecur/ent/node_query.go
@@ -360,7 +360,7 @@ func (nq *NodeQuery) sqlAll(ctx context.Context) ([]*Node, error) {
 		ids := make([]int, 0, len(nodes))
 		nodeids := make(map[int][]*Node)
 		for i := range nodes {
-			if fk := nodes[i].prev_id; fk != nil {
+			if fk := nodes[i].node_next; fk != nil {
 				ids = append(ids, *fk)
 				nodeids[*fk] = append(nodeids[*fk], nodes[i])
 			}
@@ -373,7 +373,7 @@ func (nq *NodeQuery) sqlAll(ctx context.Context) ([]*Node, error) {
 		for _, n := range neighbors {
 			nodes, ok := nodeids[n.ID]
 			if !ok {
-				return nil, fmt.Errorf(`unexpected foreign-key "prev_id" returned %v`, n.ID)
+				return nil, fmt.Errorf(`unexpected foreign-key "node_next" returned %v`, n.ID)
 			}
 			for i := range nodes {
 				nodes[i].Edges.Prev = n
@@ -397,13 +397,13 @@ func (nq *NodeQuery) sqlAll(ctx context.Context) ([]*Node, error) {
 			return nil, err
 		}
 		for _, n := range neighbors {
-			fk := n.prev_id
+			fk := n.node_next
 			if fk == nil {
-				return nil, fmt.Errorf(`foreign-key "prev_id" is nil for node %v`, n.ID)
+				return nil, fmt.Errorf(`foreign-key "node_next" is nil for node %v`, n.ID)
 			}
 			node, ok := nodeids[*fk]
 			if !ok {
-				return nil, fmt.Errorf(`unexpected foreign-key "prev_id" returned %v for node %v`, *fk, n.ID)
+				return nil, fmt.Errorf(`unexpected foreign-key "node_next" returned %v for node %v`, *fk, n.ID)
 			}
 			node.Edges.Next = n
 		}

--- a/examples/start/ent/car.go
+++ b/examples/start/ent/car.go
@@ -27,8 +27,8 @@ type Car struct {
 	RegisteredAt time.Time `json:"registered_at,omitempty"`
 	// Edges holds the relations/edges for other nodes in the graph.
 	// The values are being populated by the CarQuery when eager-loading is set.
-	Edges    CarEdges `json:"edges"`
-	owner_id *int
+	Edges     CarEdges `json:"edges"`
+	user_cars *int
 }
 
 // CarEdges holds the relations/edges for other nodes in the graph.
@@ -66,7 +66,7 @@ func (*Car) scanValues() []interface{} {
 // fkValues returns the types for scanning foreign-keys values from sql.Rows.
 func (*Car) fkValues() []interface{} {
 	return []interface{}{
-		&sql.NullInt64{}, // owner_id
+		&sql.NullInt64{}, // user_cars
 	}
 }
 
@@ -95,10 +95,10 @@ func (c *Car) assignValues(values ...interface{}) error {
 	values = values[2:]
 	if len(values) == len(car.ForeignKeys) {
 		if value, ok := values[0].(*sql.NullInt64); !ok {
-			return fmt.Errorf("unexpected type %T for edge-field owner_id", value)
+			return fmt.Errorf("unexpected type %T for edge-field user_cars", value)
 		} else if value.Valid {
-			c.owner_id = new(int)
-			*c.owner_id = int(value.Int64)
+			c.user_cars = new(int)
+			*c.user_cars = int(value.Int64)
 		}
 	}
 	return nil

--- a/examples/start/ent/car/car.go
+++ b/examples/start/ent/car/car.go
@@ -24,7 +24,7 @@ const (
 	// It exists in this package in order to avoid circular dependency with the "user" package.
 	OwnerInverseTable = "users"
 	// OwnerColumn is the table column denoting the owner relation/edge.
-	OwnerColumn = "owner_id"
+	OwnerColumn = "user_cars"
 )
 
 // Columns holds all SQL columns for car fields.
@@ -36,5 +36,5 @@ var Columns = []string{
 
 // ForeignKeys holds the SQL foreign-keys that are owned by the Car type.
 var ForeignKeys = []string{
-	"owner_id",
+	"user_cars",
 }

--- a/examples/start/ent/car_query.go
+++ b/examples/start/ent/car_query.go
@@ -335,7 +335,7 @@ func (cq *CarQuery) sqlAll(ctx context.Context) ([]*Car, error) {
 		ids := make([]int, 0, len(nodes))
 		nodeids := make(map[int][]*Car)
 		for i := range nodes {
-			if fk := nodes[i].owner_id; fk != nil {
+			if fk := nodes[i].user_cars; fk != nil {
 				ids = append(ids, *fk)
 				nodeids[*fk] = append(nodeids[*fk], nodes[i])
 			}
@@ -348,7 +348,7 @@ func (cq *CarQuery) sqlAll(ctx context.Context) ([]*Car, error) {
 		for _, n := range neighbors {
 			nodes, ok := nodeids[n.ID]
 			if !ok {
-				return nil, fmt.Errorf(`unexpected foreign-key "owner_id" returned %v`, n.ID)
+				return nil, fmt.Errorf(`unexpected foreign-key "user_cars" returned %v`, n.ID)
 			}
 			for i := range nodes {
 				nodes[i].Edges.Owner = n

--- a/examples/start/ent/migrate/schema.go
+++ b/examples/start/ent/migrate/schema.go
@@ -19,7 +19,7 @@ var (
 		{Name: "id", Type: field.TypeInt, Increment: true},
 		{Name: "model", Type: field.TypeString},
 		{Name: "registered_at", Type: field.TypeTime},
-		{Name: "owner_id", Type: field.TypeInt, Nullable: true},
+		{Name: "user_cars", Type: field.TypeInt, Nullable: true},
 	}
 	// CarsTable holds the schema information for the "cars" table.
 	CarsTable = &schema.Table{

--- a/examples/start/ent/user/user.go
+++ b/examples/start/ent/user/user.go
@@ -28,7 +28,7 @@ const (
 	// It exists in this package in order to avoid circular dependency with the "car" package.
 	CarsInverseTable = "cars"
 	// CarsColumn is the table column denoting the cars relation/edge.
-	CarsColumn = "owner_id"
+	CarsColumn = "user_cars"
 	// GroupsTable is the table the holds the groups relation/edge. The primary key declared below.
 	GroupsTable = "group_users"
 	// GroupsInverseTable is the table name for the Group entity.

--- a/examples/start/ent/user_query.go
+++ b/examples/start/ent/user_query.go
@@ -363,13 +363,13 @@ func (uq *UserQuery) sqlAll(ctx context.Context) ([]*User, error) {
 			return nil, err
 		}
 		for _, n := range neighbors {
-			fk := n.owner_id
+			fk := n.user_cars
 			if fk == nil {
-				return nil, fmt.Errorf(`foreign-key "owner_id" is nil for node %v`, n.ID)
+				return nil, fmt.Errorf(`foreign-key "user_cars" is nil for node %v`, n.ID)
 			}
 			node, ok := nodeids[*fk]
 			if !ok {
-				return nil, fmt.Errorf(`unexpected foreign-key "owner_id" returned %v for node %v`, *fk, n.ID)
+				return nil, fmt.Errorf(`unexpected foreign-key "user_cars" returned %v for node %v`, *fk, n.ID)
 			}
 			node.Edges.Cars = append(node.Edges.Cars, n)
 		}

--- a/examples/traversal/ent/group.go
+++ b/examples/traversal/ent/group.go
@@ -24,8 +24,8 @@ type Group struct {
 	Name string `json:"name,omitempty"`
 	// Edges holds the relations/edges for other nodes in the graph.
 	// The values are being populated by the GroupQuery when eager-loading is set.
-	Edges    GroupEdges `json:"edges"`
-	admin_id *int
+	Edges       GroupEdges `json:"edges"`
+	group_admin *int
 }
 
 // GroupEdges holds the relations/edges for other nodes in the graph.
@@ -73,7 +73,7 @@ func (*Group) scanValues() []interface{} {
 // fkValues returns the types for scanning foreign-keys values from sql.Rows.
 func (*Group) fkValues() []interface{} {
 	return []interface{}{
-		&sql.NullInt64{}, // admin_id
+		&sql.NullInt64{}, // group_admin
 	}
 }
 
@@ -97,10 +97,10 @@ func (gr *Group) assignValues(values ...interface{}) error {
 	values = values[1:]
 	if len(values) == len(group.ForeignKeys) {
 		if value, ok := values[0].(*sql.NullInt64); !ok {
-			return fmt.Errorf("unexpected type %T for edge-field admin_id", value)
+			return fmt.Errorf("unexpected type %T for edge-field group_admin", value)
 		} else if value.Valid {
-			gr.admin_id = new(int)
-			*gr.admin_id = int(value.Int64)
+			gr.group_admin = new(int)
+			*gr.group_admin = int(value.Int64)
 		}
 	}
 	return nil

--- a/examples/traversal/ent/group/group.go
+++ b/examples/traversal/ent/group/group.go
@@ -27,7 +27,7 @@ const (
 	// It exists in this package in order to avoid circular dependency with the "user" package.
 	AdminInverseTable = "users"
 	// AdminColumn is the table column denoting the admin relation/edge.
-	AdminColumn = "admin_id"
+	AdminColumn = "group_admin"
 )
 
 // Columns holds all SQL columns for group fields.
@@ -38,7 +38,7 @@ var Columns = []string{
 
 // ForeignKeys holds the SQL foreign-keys that are owned by the Group type.
 var ForeignKeys = []string{
-	"admin_id",
+	"group_admin",
 }
 
 var (

--- a/examples/traversal/ent/group_query.go
+++ b/examples/traversal/ent/group_query.go
@@ -424,7 +424,7 @@ func (gq *GroupQuery) sqlAll(ctx context.Context) ([]*Group, error) {
 		ids := make([]int, 0, len(nodes))
 		nodeids := make(map[int][]*Group)
 		for i := range nodes {
-			if fk := nodes[i].admin_id; fk != nil {
+			if fk := nodes[i].group_admin; fk != nil {
 				ids = append(ids, *fk)
 				nodeids[*fk] = append(nodeids[*fk], nodes[i])
 			}
@@ -437,7 +437,7 @@ func (gq *GroupQuery) sqlAll(ctx context.Context) ([]*Group, error) {
 		for _, n := range neighbors {
 			nodes, ok := nodeids[n.ID]
 			if !ok {
-				return nil, fmt.Errorf(`unexpected foreign-key "admin_id" returned %v`, n.ID)
+				return nil, fmt.Errorf(`unexpected foreign-key "group_admin" returned %v`, n.ID)
 			}
 			for i := range nodes {
 				nodes[i].Edges.Admin = n

--- a/examples/traversal/ent/migrate/schema.go
+++ b/examples/traversal/ent/migrate/schema.go
@@ -16,7 +16,7 @@ var (
 	GroupsColumns = []*schema.Column{
 		{Name: "id", Type: field.TypeInt, Increment: true},
 		{Name: "name", Type: field.TypeString},
-		{Name: "admin_id", Type: field.TypeInt, Nullable: true},
+		{Name: "group_admin", Type: field.TypeInt, Nullable: true},
 	}
 	// GroupsTable holds the schema information for the "groups" table.
 	GroupsTable = &schema.Table{
@@ -37,7 +37,7 @@ var (
 	PetsColumns = []*schema.Column{
 		{Name: "id", Type: field.TypeInt, Increment: true},
 		{Name: "name", Type: field.TypeString},
-		{Name: "owner_id", Type: field.TypeInt, Nullable: true},
+		{Name: "user_pets", Type: field.TypeInt, Nullable: true},
 	}
 	// PetsTable holds the schema information for the "pets" table.
 	PetsTable = &schema.Table{

--- a/examples/traversal/ent/pet.go
+++ b/examples/traversal/ent/pet.go
@@ -24,8 +24,8 @@ type Pet struct {
 	Name string `json:"name,omitempty"`
 	// Edges holds the relations/edges for other nodes in the graph.
 	// The values are being populated by the PetQuery when eager-loading is set.
-	Edges    PetEdges `json:"edges"`
-	owner_id *int
+	Edges     PetEdges `json:"edges"`
+	user_pets *int
 }
 
 // PetEdges holds the relations/edges for other nodes in the graph.
@@ -73,7 +73,7 @@ func (*Pet) scanValues() []interface{} {
 // fkValues returns the types for scanning foreign-keys values from sql.Rows.
 func (*Pet) fkValues() []interface{} {
 	return []interface{}{
-		&sql.NullInt64{}, // owner_id
+		&sql.NullInt64{}, // user_pets
 	}
 }
 
@@ -97,10 +97,10 @@ func (pe *Pet) assignValues(values ...interface{}) error {
 	values = values[1:]
 	if len(values) == len(pet.ForeignKeys) {
 		if value, ok := values[0].(*sql.NullInt64); !ok {
-			return fmt.Errorf("unexpected type %T for edge-field owner_id", value)
+			return fmt.Errorf("unexpected type %T for edge-field user_pets", value)
 		} else if value.Valid {
-			pe.owner_id = new(int)
-			*pe.owner_id = int(value.Int64)
+			pe.user_pets = new(int)
+			*pe.user_pets = int(value.Int64)
 		}
 	}
 	return nil

--- a/examples/traversal/ent/pet/pet.go
+++ b/examples/traversal/ent/pet/pet.go
@@ -24,7 +24,7 @@ const (
 	// It exists in this package in order to avoid circular dependency with the "user" package.
 	OwnerInverseTable = "users"
 	// OwnerColumn is the table column denoting the owner relation/edge.
-	OwnerColumn = "owner_id"
+	OwnerColumn = "user_pets"
 )
 
 // Columns holds all SQL columns for pet fields.
@@ -35,7 +35,7 @@ var Columns = []string{
 
 // ForeignKeys holds the SQL foreign-keys that are owned by the Pet type.
 var ForeignKeys = []string{
-	"owner_id",
+	"user_pets",
 }
 
 var (

--- a/examples/traversal/ent/pet_query.go
+++ b/examples/traversal/ent/pet_query.go
@@ -424,7 +424,7 @@ func (pq *PetQuery) sqlAll(ctx context.Context) ([]*Pet, error) {
 		ids := make([]int, 0, len(nodes))
 		nodeids := make(map[int][]*Pet)
 		for i := range nodes {
-			if fk := nodes[i].owner_id; fk != nil {
+			if fk := nodes[i].user_pets; fk != nil {
 				ids = append(ids, *fk)
 				nodeids[*fk] = append(nodeids[*fk], nodes[i])
 			}
@@ -437,7 +437,7 @@ func (pq *PetQuery) sqlAll(ctx context.Context) ([]*Pet, error) {
 		for _, n := range neighbors {
 			nodes, ok := nodeids[n.ID]
 			if !ok {
-				return nil, fmt.Errorf(`unexpected foreign-key "owner_id" returned %v`, n.ID)
+				return nil, fmt.Errorf(`unexpected foreign-key "user_pets" returned %v`, n.ID)
 			}
 			for i := range nodes {
 				nodes[i].Edges.Owner = n

--- a/examples/traversal/ent/user/user.go
+++ b/examples/traversal/ent/user/user.go
@@ -24,7 +24,7 @@ const (
 	// It exists in this package in order to avoid circular dependency with the "pet" package.
 	PetsInverseTable = "pets"
 	// PetsColumn is the table column denoting the pets relation/edge.
-	PetsColumn = "owner_id"
+	PetsColumn = "user_pets"
 	// FriendsTable is the table the holds the friends relation/edge. The primary key declared below.
 	FriendsTable = "user_friends"
 	// GroupsTable is the table the holds the groups relation/edge. The primary key declared below.
@@ -38,7 +38,7 @@ const (
 	// It exists in this package in order to avoid circular dependency with the "group" package.
 	ManageInverseTable = "groups"
 	// ManageColumn is the table column denoting the manage relation/edge.
-	ManageColumn = "admin_id"
+	ManageColumn = "group_admin"
 )
 
 // Columns holds all SQL columns for user fields.

--- a/examples/traversal/ent/user_query.go
+++ b/examples/traversal/ent/user_query.go
@@ -413,13 +413,13 @@ func (uq *UserQuery) sqlAll(ctx context.Context) ([]*User, error) {
 			return nil, err
 		}
 		for _, n := range neighbors {
-			fk := n.owner_id
+			fk := n.user_pets
 			if fk == nil {
-				return nil, fmt.Errorf(`foreign-key "owner_id" is nil for node %v`, n.ID)
+				return nil, fmt.Errorf(`foreign-key "user_pets" is nil for node %v`, n.ID)
 			}
 			node, ok := nodeids[*fk]
 			if !ok {
-				return nil, fmt.Errorf(`unexpected foreign-key "owner_id" returned %v for node %v`, *fk, n.ID)
+				return nil, fmt.Errorf(`unexpected foreign-key "user_pets" returned %v for node %v`, *fk, n.ID)
 			}
 			node.Edges.Pets = append(node.Edges.Pets, n)
 		}
@@ -567,13 +567,13 @@ func (uq *UserQuery) sqlAll(ctx context.Context) ([]*User, error) {
 			return nil, err
 		}
 		for _, n := range neighbors {
-			fk := n.admin_id
+			fk := n.group_admin
 			if fk == nil {
-				return nil, fmt.Errorf(`foreign-key "admin_id" is nil for node %v`, n.ID)
+				return nil, fmt.Errorf(`foreign-key "group_admin" is nil for node %v`, n.ID)
 			}
 			node, ok := nodeids[*fk]
 			if !ok {
-				return nil, fmt.Errorf(`unexpected foreign-key "admin_id" returned %v for node %v`, *fk, n.ID)
+				return nil, fmt.Errorf(`unexpected foreign-key "group_admin" returned %v for node %v`, *fk, n.ID)
 			}
 			node.Edges.Manage = append(node.Edges.Manage, n)
 		}


### PR DESCRIPTION
Also, add a "fixture" logic to the migration to make this change backward compatible.

Fixes #285