### PR TITLE
ci: pin mysql8 to mysql 8.0.18 (not latest)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,7 +67,7 @@ jobs:
         environment:
           <<: *mysql_env
           MYSQL_TCP_PORT: 3307
-      - image: circleci/mysql:8
+      - image: circleci/mysql:8.0.18
         environment:
           <<: *mysql_env
           MYSQL_TCP_PORT: 3308


### PR DESCRIPTION
Following my bug report in MySQL issue tracker,
I've pinned MySQL8 version to be 8.0.18 until
we figure out if it's a bug or a new change that
we need to support.

Link: https://bugs.mysql.com/bug.php?id=98250