### PR TITLE
Provide a flag to disable example test generation

### DIFF
--- a/cmd/entc/entc.go
+++ b/cmd/entc/entc.go
@@ -113,6 +113,7 @@ func main() {
 			cmd.Flags().StringVar(&cfg.Header, "header", "", "override codegen header")
 			cmd.Flags().StringVar(&cfg.Target, "target", "", "target directory for codegen")
 			cmd.Flags().StringSliceVarP(&template, "template", "", nil, "external templates to execute")
+			cmd.Flags().StringVar(&cfg.SkipGraphTemplate, "skip", "example", "skip schema example_test")
 			return cmd
 		}(),
 	)

--- a/entc/gen/graph.go
+++ b/entc/gen/graph.go
@@ -30,6 +30,8 @@ type (
 		Target string
 		// Package name for the targeted directory that holds the generated code.
 		Package string
+		// SkipGraphTemplate support skip GraphTemplate such as example_test.go
+		SkipGraphTemplate string
 		// Header is an optional header signature for generated files.
 		Header string
 		// Storage to support in codegen.
@@ -379,6 +381,10 @@ func (g *Graph) Tables() (all []*schema.Table) {
 // SupportMigrate reports if the codegen supports schema migration.
 func (g *Graph) SupportMigrate() bool {
 	return g.Storage.SchemaMode.Support(Migrate)
+}
+
+func (g *Graph) SkipExampleTest() bool {
+	return g.Config.SkipGraphTemplate == "example"
 }
 
 func (g *Graph) typ(name string) (*Type, bool) {

--- a/entc/gen/template.go
+++ b/entc/gen/template.go
@@ -107,6 +107,7 @@ var (
 		{
 			Name:   "example",
 			Format: "example_test.go",
+			Skip:   func(g *Graph) bool { return g.SkipExampleTest() },
 		},
 	}
 	// templates holds the Go templates for the code generation.


### PR DESCRIPTION
Provide a flag to disable example test generation，solve https://github.com/facebookincubator/ent/issues/297.
In my opinion,that is a very unattractive feature of a code generator to generate example_test file.

