### PR TITLE
dialect/sql: add change-column for mysql

### DIFF
--- a/dialect/sql/builder.go
+++ b/dialect/sql/builder.go
@@ -252,6 +252,13 @@ func (t *TableAlter) DropColumn(c *ColumnBuilder) *TableAlter {
 	return t
 }
 
+// ChangeColumn appends the `CHANGE COLUMN` clause to the given `ALTER TABLE` statement.
+func (t *TableAlter) ChangeColumn(name string, c *ColumnBuilder) *TableAlter {
+	prefix := fmt.Sprintf("CHANGE COLUMN %s", t.Quote(name))
+	t.Queries = append(t.Queries, &Wrapper{prefix + " %s", c})
+	return t
+}
+
 // RenameIndex appends the `RENAME INDEX` clause to the given `ALTER TABLE` statement.
 func (t *TableAlter) RenameIndex(curr, new string) *TableAlter {
 	t.Queries = append(t.Queries, Raw(fmt.Sprintf("RENAME INDEX %s TO %s", t.Quote(curr), t.Quote(new))))

--- a/dialect/sql/builder_test.go
+++ b/dialect/sql/builder_test.go
@@ -185,6 +185,11 @@ func TestBuilder(t *testing.T) {
 			wantQuery: `ALTER TABLE "users" ALTER COLUMN "age" TYPE int, ALTER COLUMN "age" SET NOT NULL, ALTER COLUMN "name" DROP NOT NULL`,
 		},
 		{
+			input: AlterTable("users").
+				ChangeColumn("old_age", Column("age").Type("int")),
+			wantQuery: "ALTER TABLE `users` CHANGE COLUMN `old_age` `age` int",
+		},
+		{
 			input: Dialect(dialect.Postgres).AlterTable("users").
 				AddColumn(Column("boring").Type("varchar")).
 				ModifyColumn(Column("age").Type("int")).


### PR DESCRIPTION
Old versions of MySQL (<8) do not support the 'RENAME' caluse