### PR TITLE
dialect/sql: allow nil values for exec commands

### DIFF
--- a/dialect/sql/schema/migrate.go
+++ b/dialect/sql/schema/migrate.go
@@ -127,7 +127,7 @@ func (m *Migrate) create(ctx context.Context, tx dialect.Tx, tables ...*Table) e
 			}
 		default: // !exist
 			query, args := m.tBuilder(t).Query()
-			if err := tx.Exec(ctx, query, args, new(sql.Result)); err != nil {
+			if err := tx.Exec(ctx, query, args, nil); err != nil {
 				return fmt.Errorf("create table %q: %v", t.Name, err)
 			}
 			// if global unique identifier is enabled and it's not a relation table,
@@ -140,7 +140,7 @@ func (m *Migrate) create(ctx context.Context, tx dialect.Tx, tables ...*Table) e
 			// indexes.
 			for _, idx := range t.Indexes {
 				query, args := m.addIndex(idx, t.Name).Query()
-				if err := tx.Exec(ctx, query, args, new(sql.Result)); err != nil {
+				if err := tx.Exec(ctx, query, args, nil); err != nil {
 					return fmt.Errorf("create index %q: %v", idx.Name, err)
 				}
 			}
@@ -170,7 +170,7 @@ func (m *Migrate) create(ctx context.Context, tx dialect.Tx, tables ...*Table) e
 			b.AddForeignKey(fk.DSL())
 		}
 		query, args := b.Query()
-		if err := tx.Exec(ctx, query, args, new(sql.Result)); err != nil {
+		if err := tx.Exec(ctx, query, args, nil); err != nil {
 			return fmt.Errorf("create foreign keys for %q: %v", t.Name, err)
 		}
 	}
@@ -209,13 +209,13 @@ func (m *Migrate) apply(ctx context.Context, tx dialect.Tx, table string, change
 	// if there's actual action to execute on ALTER TABLE.
 	if len(b.Queries) != 0 {
 		query, args := b.Query()
-		if err := tx.Exec(ctx, query, args, new(sql.Result)); err != nil {
+		if err := tx.Exec(ctx, query, args, nil); err != nil {
 			return fmt.Errorf("alter table %q: %v", table, err)
 		}
 	}
 	for _, idx := range change.index.add {
 		query, args := m.addIndex(idx, table).Query()
-		if err := tx.Exec(ctx, query, args, new(sql.Result)); err != nil {
+		if err := tx.Exec(ctx, query, args, nil); err != nil {
 			return fmt.Errorf("create index %q: %v", table, err)
 		}
 	}
@@ -344,7 +344,7 @@ func (m *Migrate) types(ctx context.Context, tx dialect.Tx) error {
 			AddPrimary(&Column{Name: "id", Type: field.TypeInt, Increment: true}).
 			AddColumn(&Column{Name: "type", Type: field.TypeString, Unique: true})
 		query, args := m.tBuilder(t).Query()
-		if err := tx.Exec(ctx, query, args, new(sql.Result)); err != nil {
+		if err := tx.Exec(ctx, query, args, nil); err != nil {
 			return fmt.Errorf("create types table: %v", err)
 		}
 		return nil
@@ -375,7 +375,7 @@ func (m *Migrate) allocPKRange(ctx context.Context, tx dialect.Tx, t *Table) err
 		}
 		query, args := sql.Dialect(m.Dialect()).
 			Insert(TypeTable).Columns("type").Values(t.Name).Query()
-		if err := tx.Exec(ctx, query, args, new(sql.Result)); err != nil {
+		if err := tx.Exec(ctx, query, args, nil); err != nil {
 			return fmt.Errorf("insert into type: %v", err)
 		}
 		id = len(m.typeRanges)

--- a/dialect/sql/schema/mysql.go
+++ b/dialect/sql/schema/mysql.go
@@ -109,7 +109,7 @@ func (d *MySQL) indexes(ctx context.Context, tx dialect.Tx, name string) ([]*Ind
 }
 
 func (d *MySQL) setRange(ctx context.Context, tx dialect.Tx, name string, value int) error {
-	return tx.Exec(ctx, fmt.Sprintf("ALTER TABLE `%s` AUTO_INCREMENT = %d", name, value), []interface{}{}, new(sql.Result))
+	return tx.Exec(ctx, fmt.Sprintf("ALTER TABLE `%s` AUTO_INCREMENT = %d", name, value), []interface{}{}, nil)
 }
 
 // tBuilder returns the MySQL DSL query for table creation.
@@ -226,7 +226,7 @@ func (d *MySQL) addIndex(i *Index, table string) *sql.IndexBuilder {
 // dropIndex drops a MySQL index.
 func (d *MySQL) dropIndex(ctx context.Context, tx dialect.Tx, idx *Index, table string) error {
 	query, args := idx.DropBuilder(table).Query()
-	return tx.Exec(ctx, query, args, new(sql.Result))
+	return tx.Exec(ctx, query, args, nil)
 }
 
 // prepare runs preparation work that needs to be done to apply the change-set.
@@ -270,7 +270,7 @@ func (d *MySQL) prepare(ctx context.Context, tx dialect.Tx, change *changes, tab
 		}
 		if qr != nil {
 			query, args := qr.Query()
-			if err := tx.Exec(ctx, query, args, new(sql.Result)); err != nil {
+			if err := tx.Exec(ctx, query, args, nil); err != nil {
 				return err
 			}
 		}

--- a/dialect/sql/schema/postgres.go
+++ b/dialect/sql/schema/postgres.go
@@ -66,7 +66,7 @@ func (d *Postgres) setRange(ctx context.Context, tx dialect.Tx, name string, val
 	if value == 0 {
 		value = 1 // RESTART value cannot be < 1.
 	}
-	return tx.Exec(ctx, fmt.Sprintf("ALTER TABLE %s ALTER COLUMN id RESTART WITH %d", name, value), []interface{}{}, new(sql.Result))
+	return tx.Exec(ctx, fmt.Sprintf("ALTER TABLE %s ALTER COLUMN id RESTART WITH %d", name, value), []interface{}{}, nil)
 }
 
 // table loads the current table description from the database.
@@ -349,5 +349,5 @@ func (d *Postgres) dropIndex(ctx context.Context, tx dialect.Tx, idx *Index, tab
 	if exists {
 		query, args = build.AlterTable(table).DropConstraint(name).Query()
 	}
-	return tx.Exec(ctx, query, args, new(sql.Result))
+	return tx.Exec(ctx, query, args, nil)
 }

--- a/dialect/sql/schema/sqlite.go
+++ b/dialect/sql/schema/sqlite.go
@@ -59,7 +59,7 @@ func (d *SQLite) setRange(ctx context.Context, tx dialect.Tx, name string, value
 	default: // !exists
 		query, args = sql.Insert("sqlite_sequence").Columns("name", "seq").Values(name, value).Query()
 	}
-	return tx.Exec(ctx, query, args, new(sql.Result))
+	return tx.Exec(ctx, query, args, nil)
 }
 
 func (d *SQLite) tBuilder(t *Table) *sql.TableBuilder {
@@ -144,7 +144,7 @@ func (d *SQLite) addIndex(i *Index, table string) *sql.IndexBuilder {
 // dropIndex drops a SQLite index.
 func (d *SQLite) dropIndex(ctx context.Context, tx dialect.Tx, idx *Index, table string) error {
 	query, args := idx.DropBuilder("").Query()
-	return tx.Exec(ctx, query, args, new(sql.Result))
+	return tx.Exec(ctx, query, args, nil)
 }
 
 // fkExist returns always true to disable foreign-keys creation after the table was created.


### PR DESCRIPTION
In most cases, the sql.Result is not needed.