### PR TITLE
delete TMPDIR/ent generated by go test

### DIFF
--- a/entc/gen/graph_test.go
+++ b/entc/gen/graph_test.go
@@ -241,4 +241,5 @@ func TestGraph_Gen(t *testing.T) {
 	}
 	_, err = os.Stat(target + "/external.go")
 	require.NoError(err)
+	os.RemoveAll(target)
 }


### PR DESCRIPTION
Solve https://github.com/facebookincubator/ent/issues/307
After running go test -v to test the project, the dir ent will be generated in $TMPDIR, I think we should delete the ent after test just in case, or it will affect the test result next time in some unknown cases.