### PR TITLE
dialect/sql/schema: initial work for incremental migration

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -57,9 +57,9 @@ issues:
       text: "SQL string concatenation"
       linters:
         - gosec
-    - path: dialect/sql/schema/migrate.go
-      text: "weak cryptographic primitive"
+    - path: dialect/sql/schema
       linters:
+        - dupl
         - gosec
     - path: entc/load/load.go
       text: "packages.LoadSyntax is deprecated"

--- a/dialect/sql/builder_test.go
+++ b/dialect/sql/builder_test.go
@@ -1164,6 +1164,20 @@ func TestBuilder(t *testing.T) {
 			input:     DropIndex("name_index").Table("users"),
 			wantQuery: "DROP INDEX `name_index` ON `users`",
 		},
+		{
+			input: Select().
+				From(Table("pragma_table_info('t1')").Unquote()).
+				OrderBy("pk"),
+			wantQuery: "SELECT * FROM pragma_table_info('t1') ORDER BY `pk`",
+		},
+		{
+			input: AlterTable("users").
+				AddColumn(Column("spouse").Type("integer").
+					Constraint(ForeignKey("user_spouse").
+						Reference(Reference().Table("users").Columns("id")).
+						OnDelete("SET NULL"))),
+			wantQuery: "ALTER TABLE `users` ADD COLUMN `spouse` integer CONSTRAINT user_spouse REFERENCES `users`(`id`) ON DELETE SET NULL",
+		},
 	}
 	for i, tt := range tests {
 		t.Run(strconv.Itoa(i), func(t *testing.T) {

--- a/dialect/sql/schema/mysql_test.go
+++ b/dialect/sql/schema/mysql_test.go
@@ -388,7 +388,7 @@ func TestMySQL_Create(t *testing.T) {
 			},
 		},
 		{
-			name: "add bool column with default value to table",
+			name: "add bool column with default value",
 			tables: []*Table{
 				{
 					Name: "users",
@@ -420,7 +420,7 @@ func TestMySQL_Create(t *testing.T) {
 			},
 		},
 		{
-			name: "add string column with default value to table",
+			name: "add string column with default value",
 			tables: []*Table{
 				{
 					Name: "users",
@@ -452,7 +452,7 @@ func TestMySQL_Create(t *testing.T) {
 			},
 		},
 		{
-			name: "add column with unsupported default value to table",
+			name: "add column with unsupported default value",
 			tables: []*Table{
 				{
 					Name: "users",
@@ -484,7 +484,7 @@ func TestMySQL_Create(t *testing.T) {
 			},
 		},
 		{
-			name: "drop column to table",
+			name: "drop columns",
 			tables: []*Table{
 				{
 					Name: "users",

--- a/dialect/sql/schema/schema.go
+++ b/dialect/sql/schema/schema.go
@@ -98,7 +98,6 @@ func (t *Table) column(name string) (*Column, bool) {
 }
 
 // index returns a table index by its name.
-// faster than map lookup for most cases.
 func (t *Table) index(name string) (*Index, bool) {
 	for _, idx := range t.Indexes {
 		if idx.Name == name {
@@ -150,6 +149,7 @@ type Column struct {
 	Default   interface{} // default value.
 	Enums     []string    // enum values.
 	indexes   Indexes     // linked indexes.
+	foreign   *ForeignKey // linked foreign-key.
 }
 
 // UniqueKey returns boolean indicates if this column is a unique key.
@@ -186,7 +186,7 @@ func (c Column) FloatType() bool { return c.Type == field.TypeFloat32 || c.Type 
 // ScanDefault scans the default value string to its interface type.
 func (c *Column) ScanDefault(value string) (err error) {
 	switch {
-	case value == Null: // ignore.
+	case strings.ToUpper(value) == Null: // ignore.
 	case c.IntType():
 		v := &sql.NullInt64{}
 		if err := v.Scan(value); err != nil {

--- a/entc/integration/migrate/migrate_test.go
+++ b/entc/integration/migrate/migrate_test.go
@@ -78,7 +78,7 @@ func TestSQLite(t *testing.T) {
 
 	ctx := context.Background()
 	client := entv2.NewClient(entv2.Driver(drv))
-	require.NoError(t, client.Schema.Create(ctx, migratev2.WithGlobalUniqueID(true)))
+	require.NoError(t, client.Schema.Create(ctx, migratev2.WithGlobalUniqueID(true)), migratev2.WithDropIndex(true))
 
 	SanityV2(t, client)
 	idRange(t, client.Car.Create().SaveX(ctx).ID, 0, 1<<32)


### PR DESCRIPTION
This is a modified version of PR #221 created by Erik Hollensbe (@erikh). 
It adds basic functionality like adding fields/edges for schemas, but dropping/modifying columns or constraints is not working at the moment. 
