### PR TITLE
Split strings in pascal/camcelCase conversion on - in addition to _

### DIFF
--- a/entc/gen/func.go
+++ b/entc/gen/func.go
@@ -108,14 +108,11 @@ func plural(name string) string {
 	return p
 }
 
-// pascal converts the given column name into a PascalCase.
-//
-//	user_info => UserInfo
-//	full_name => FullName
-//	user_id   => UserID
-//
-func pascal(s string) string {
-	words := strings.Split(s, "_")
+func isSeparator(r rune) bool {
+	return r == '_' || r == '-'
+}
+
+func pascalWords(words []string) string {
 	for i, w := range words {
 		upper := strings.ToUpper(w)
 		if _, ok := acronyms[upper]; ok {
@@ -127,18 +124,31 @@ func pascal(s string) string {
 	return strings.Join(words, "")
 }
 
-// camel converts the given column name into a camelCase.
+// pascal converts the given name into a PascalCase.
 //
-//	user_info => userInfo
-//	full_name => fullName
-//	user_id   => userID
+//	user_info => UserInfo
+//	full_name => FullName
+//	user_id   => UserID
+//	full-admin   => FullAdmin
+//
+func pascal(s string) string {
+	words := strings.FieldsFunc(s, isSeparator)
+	return pascalWords(words)
+}
+
+// camel converts the given name into a camelCase.
+//
+//	user_info  => userInfo
+//	full_name  => fullName
+//	user_id    => userID
+//	full-admin => fullAdmin
 //
 func camel(s string) string {
-	words := strings.SplitN(s, "_", 2)
+	words := strings.FieldsFunc(s, isSeparator)
 	if len(words) == 1 {
 		return strings.ToLower(words[0])
 	}
-	return strings.ToLower(words[0]) + pascal(words[1])
+	return strings.ToLower(words[0]) + pascalWords(words[1:])
 }
 
 // snake converts the given struct or field name into a snake_case.

--- a/entc/integration/ent/migrate/schema.go
+++ b/entc/integration/ent/migrate/schema.go
@@ -323,7 +323,7 @@ var (
 		{Name: "nickname", Type: field.TypeString, Unique: true, Nullable: true},
 		{Name: "phone", Type: field.TypeString, Unique: true, Nullable: true},
 		{Name: "password", Type: field.TypeString, Nullable: true},
-		{Name: "role", Type: field.TypeEnum, Enums: []string{"admin", "user"}, Default: "user"},
+		{Name: "role", Type: field.TypeEnum, Enums: []string{"admin", "free-user", "user"}, Default: "user"},
 		{Name: "sso_cert", Type: field.TypeString, Nullable: true},
 		{Name: "group_blocked", Type: field.TypeInt, Nullable: true},
 		{Name: "user_spouse", Type: field.TypeInt, Unique: true, Nullable: true},

--- a/entc/integration/ent/schema/user.go
+++ b/entc/integration/ent/schema/user.go
@@ -41,7 +41,7 @@ func (User) Fields() []ent.Field {
 			Optional().
 			Sensitive(),
 		field.Enum("role").
-			Values("user", "admin").
+			Values("user", "admin", "free-user").
 			Default("user"),
 		field.String("SSOCert").
 			Optional(),

--- a/entc/integration/ent/user/user.go
+++ b/entc/integration/ent/user/user.go
@@ -163,8 +163,9 @@ const DefaultRole = RoleUser
 
 // Role values.
 const (
-	RoleAdmin Role = "admin"
-	RoleUser  Role = "user"
+	RoleAdmin    Role = "admin"
+	RoleFreeUser Role = "free-user"
+	RoleUser     Role = "user"
 )
 
 func (r Role) String() string {
@@ -174,7 +175,7 @@ func (r Role) String() string {
 // RoleValidator is a validator for the "role" field enum values. It is called by the builders before save.
 func RoleValidator(r Role) error {
 	switch r {
-	case RoleAdmin, RoleUser:
+	case RoleAdmin, RoleFreeUser, RoleUser:
 		return nil
 	default:
 		return fmt.Errorf("user: invalid enum value for role field: %q", r)

--- a/entc/integration/gremlin/ent/user/user.go
+++ b/entc/integration/gremlin/ent/user/user.go
@@ -96,8 +96,9 @@ const DefaultRole = RoleUser
 
 // Role values.
 const (
-	RoleAdmin Role = "admin"
-	RoleUser  Role = "user"
+	RoleAdmin    Role = "admin"
+	RoleFreeUser Role = "free-user"
+	RoleUser     Role = "user"
 )
 
 func (r Role) String() string {
@@ -107,7 +108,7 @@ func (r Role) String() string {
 // RoleValidator is a validator for the "role" field enum values. It is called by the builders before save.
 func RoleValidator(r Role) error {
 	switch r {
-	case RoleAdmin, RoleUser:
+	case RoleAdmin, RoleFreeUser, RoleUser:
 		return nil
 	default:
 		return fmt.Errorf("user: invalid enum value for role field: %q", r)


### PR DESCRIPTION
I've been evaluating Ent for production use and ran into a small issue with the code gen and enums. If an enum string value is `kebab-case` the generated go code isn't valid. For example:

```go
...
		field.Enum("role").
			Values("user", "admin", "free-user").
			Default("user")
...
```

Generates:

```go
...
// Role values.
const (
		RoleUser Role = "user"
		RoleAdmin Role = "admin"
		RoleFree-user Role = "free-user"
)
...
```

The issue is `RoleFree-user` isn't a valid Go variable name.

I've enhanced the Pascal/camelCase string conversion functions to split on `-` as well as `_`. The resulting code gen is more expected:

```go
// Role values.
const (
	RoleUser     Role = "user"
	RoleAdmin    Role = "admin"
	RoleUser     Role = "user"
	RoleAdmin    Role = "admin"
	RoleFreeUser Role = "free-user"
)
```